### PR TITLE
fixes reset looping through a hash and not array

### DIFF
--- a/dist/twine.js
+++ b/dist/twine.js
@@ -19,16 +19,17 @@ refreshQueued = false;
 rootNode = null;
 
 Twine.reset = function(newContext, node) {
-  var bindingsArr, obj, _i, _j, _len, _len1;
+  var bindings, key, obj, _i, _len, _ref;
   if (node == null) {
     node = document.documentElement;
   }
-  for (_i = 0, _len = elements.length; _i < _len; _i++) {
-    bindingsArr = elements[_i];
-    for (_j = 0, _len1 = bindingsArr.length; _j < _len1; _j++) {
-      obj = bindingsArr[_j];
-      if (obj.teardown) {
-        obj.teardown();
+  for (key in elements) {
+    if (bindings = (_ref = elements[key]) != null ? _ref.bindings : void 0) {
+      for (_i = 0, _len = bindings.length; _i < _len; _i++) {
+        obj = bindings[_i];
+        if (obj.teardown) {
+          obj.teardown();
+        }
       }
     }
   }

--- a/lib/assets/javascripts/twine.js.coffee
+++ b/lib/assets/javascripts/twine.js.coffee
@@ -17,8 +17,10 @@ rootNode = null
 
 # Cleans up all existing bindings and sets the root node and context.
 Twine.reset = (newContext, node = document.documentElement) ->
-  for bindingsArr in elements
-    obj.teardown() for obj in bindingsArr when obj.teardown
+  for key of elements
+    if bindings = elements[key]?.bindings
+      obj.teardown() for obj in bindings when obj.teardown
+
   elements = {}
 
   rootContext = newContext

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -416,6 +416,15 @@ suite "Twine", ->
       assert.equal rootNode.bindingId, 1
       assert.equal Twine.context(rootNode), context
 
+    test "should teardown all elements in memory", ->
+      testView = "<div bind-event-click=\"fn()\"></div>"
+      node = setupView(testView, context = fn: @spy())
+      Twine.bind(node)
+      Twine.reset({}, rootNode)
+
+      $(node).click()
+      assert.equal context.fn.callCount, 0
+
   test "context should return the node's context", ->
     testView = '<div context="inner"><div context="inner"></div></div>'
     node = setupView(testView, context = {inner: {inner: {}}})


### PR DESCRIPTION
@qq99 @nsimmons @pushrax 
this fixes https://github.com/Shopify/twine/issues/13

It was not only a `s/in/of/` as the loop itself was broken. Now it's pretty similar to what we have in the `unbind` function.
