### PR TITLE
adding src attribute binding

### DIFF
--- a/dist/twine.js
+++ b/dist/twine.js
@@ -438,7 +438,7 @@ setupAttributeBinding = function(attributeName, bindingName) {
   };
 };
 
-_ref = ['placeholder', 'checked', 'disabled', 'href', 'title', 'readOnly'];
+_ref = ['placeholder', 'checked', 'disabled', 'href', 'title', 'readOnly', 'src'];
 for (_i = 0, _len = _ref.length; _i < _len; _i++) {
   attribute = _ref[_i];
   setupAttributeBinding(attribute, attribute);

--- a/lib/assets/javascripts/twine.js.coffee
+++ b/lib/assets/javascripts/twine.js.coffee
@@ -270,7 +270,7 @@ setupAttributeBinding = (attributeName, bindingName) ->
       return if newValue == lastValue
       node[attributeName] = lastValue = newValue
 
-for attribute in ['placeholder', 'checked', 'disabled', 'href', 'title', 'readOnly']
+for attribute in ['placeholder', 'checked', 'disabled', 'href', 'title', 'readOnly', 'src']
   setupAttributeBinding(attribute, attribute)
 
 setupAttributeBinding('innerHTML', 'unsafe-html')

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -230,6 +230,12 @@ suite "Twine", ->
       node = setupView(testView, key: "&amp;")
       assert.equal node.innerHTML, "&amp;"
 
+  suite "bind-src attribute", ->
+    test "should set the src of the node", ->
+      testView = '<img bind-src="key"></div>'
+      node = setupView(testView, key: "image.jpg")
+      assert.match node.src, /\/image\.jpg$/
+
   suite "bind-event-* attribute", ->
     test "should not run the handler when not allowed", ->
       testView = "<div bind-event-click=\"fn()\"></div>"


### PR DESCRIPTION
@nsimmons @pushrax @qq99 

We have no support for `bind-src` yet. This PR adds it. 
Pretty simple and straightforward. 
