### PR TITLE
Let unbind handle undefined node

### DIFF
--- a/dist/twine.js
+++ b/dist/twine.js
@@ -134,6 +134,9 @@ Twine.change = function(node, bubble) {
 
 Twine.unbind = function(node) {
   var bindings, childNode, id, obj, _i, _j, _len, _len1, _ref, _ref1;
+  if (!node) {
+    return;
+  }
   if (id = node.bindingId) {
     if (bindings = (_ref = elements[id]) != null ? _ref.bindings : void 0) {
       for (_i = 0, _len = bindings.length; _i < _len; _i++) {

--- a/lib/assets/javascripts/twine.js.coffee
+++ b/lib/assets/javascripts/twine.js.coffee
@@ -84,6 +84,8 @@ Twine.change = (node, bubble = false) ->
 
 # Cleans up everything related to a node and its subtree.
 Twine.unbind = (node) ->
+  return unless node
+
   if id = node.bindingId
     if bindings = elements[id]?.bindings
       obj.teardown() for obj in bindings when obj.teardown

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -418,6 +418,32 @@ suite "Twine", ->
       $(node).click()
       assert.isTrue context.fn.calledOnce
 
+  suite "unbind", ->
+    test "should unbind a previously bound node", ->
+      testView = "<div bind='test'></div>"
+      node = setupView(testView, context = {})
+
+      assert node.bindingId
+
+      Twine.unbind(node)
+
+      assert.isUndefined node.bindingId
+
+    test "should unbind children", ->
+      testView = "<div bind='test'><div bind='somethingElse'></div></div>"
+      node = setupView(testView, context = {})
+
+      assert node.bindingId
+      assert node.firstChild.bindingId
+
+      Twine.unbind(node)
+
+      assert.isUndefined node.bindingId
+      assert.isUndefined node.firstChild.bindingId
+
+    test "should ignore undefned nodes", ->
+      assert.isUndefined Twine.unbind(undefined)
+
   suite "reset", ->
     test "should set up the root node", ->
       Twine.reset(context = {}, rootNode)


### PR DESCRIPTION
### Problem

In a very dynamic situation it might be possible to call unbind on an node that is already deleted. In that case the `node` parameter is `undefined` and should be ignored instead of exploding.
### Solution

Return if node is not defined. Also added some missing tests for unbind.

@pushrax @qq99 @celsodantas 
/cc @DrewMartin 
