### PR TITLE
Bindings finished

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ $(document).ajaxComplete ->
 
 ## Twine.register
 
-Optionally register a callback that will be called when the context that registers it is finished binding.
+Registers a function to be called when the currently binding node and its children have finished binding.
 
 Example:
 
@@ -106,6 +106,9 @@ Example:
     constructor: ->
       Twine.register ->
         console.log("done")
+
+    # other methods needed in the context
+    # ...
 ```
 
 ```html

--- a/README.md
+++ b/README.md
@@ -95,6 +95,23 @@ $(document).ajaxComplete ->
   Twine.refresh()
 ```
 
+## bindingsFinished
+
+When a node and its children are finished binding Twine checks the context for a function `bindingsFinished` and calls it if its present. This function will only be called once per context.
+
+Example:
+
+```html
+<div define="bindingsFinished: function() { console.log("done"); }"></div>
+
+<script>
+  var foo = { bindingsFinished: function() { console.log("done"); } }
+</script>
+
+<div context="foo">
+</div>
+```
+
 ## Contributing
 
 1. Clone the repo: `git clone git@github.com:Shopify/twine`

--- a/README.md
+++ b/README.md
@@ -95,21 +95,21 @@ $(document).ajaxComplete ->
   Twine.refresh()
 ```
 
-## bindingsFinished
+## Twine.register
 
-When a node and its children are finished binding Twine checks the context for a function `bindingsFinished` and calls it if its present. This function will only be called once per context.
+Optionally register a callback that will be called when the context that registers it is finished binding.
 
 Example:
 
+```coffee
+  class Foo
+    constructor: ->
+      Twine.register ->
+        console.log("done")
+```
+
 ```html
-<div define="bindingsFinished: function() { console.log("done"); }"></div>
-
-<script>
-  var foo = { bindingsFinished: function() { console.log("done"); } }
-</script>
-
-<div context="foo">
-</div>
+<div context='bar' define='{bar: new Foo}'></div>
 ```
 
 ## Contributing

--- a/dist/twine.js
+++ b/dist/twine.js
@@ -61,7 +61,7 @@ Twine.register = function(callback) {
 };
 
 bind = function(context, node, forceSaveContext) {
-  var binding, callback, callbacks, childNode, definition, element, fn, keypath, newContextKey, type, _i, _j, _len, _len1, _ref, _ref1;
+  var binding, callback, callbacks, childNode, definition, element, fn, keypath, newContextKey, type, _i, _j, _len, _len1, _ref, _ref1, _ref2;
   currentBindingCallbacks = [];
   if (node.bindingId) {
     Twine.unbind(node);
@@ -101,8 +101,9 @@ bind = function(context, node, forceSaveContext) {
     bind(context, childNode);
   }
   Twine.count = nodeCount;
-  for (_j = 0, _len1 = callbacks.length; _j < _len1; _j++) {
-    callback = callbacks[_j];
+  _ref2 = callbacks || [];
+  for (_j = 0, _len1 = _ref2.length; _j < _len1; _j++) {
+    callback = _ref2[_j];
     callback();
   }
   currentBindingCallbacks = null;

--- a/dist/twine.js
+++ b/dist/twine.js
@@ -51,7 +51,7 @@ Twine.bind = function(node, context) {
 };
 
 bind = function(context, node, forceSaveContext) {
-  var binding, childNode, definition, element, fn, keypath, newContextKey, type, _i, _len, _ref, _ref1;
+  var binding, childNode, definition, element, finalization, fn, keypath, newContextKey, type, _i, _len, _ref, _ref1;
   if (node.bindingId) {
     Twine.unbind(node);
   }
@@ -79,6 +79,11 @@ bind = function(context, node, forceSaveContext) {
     }
     context = getValue(context, keypath) || setValue(context, keypath, {});
   }
+  finalization = null;
+  if ((context != null ? context.bindingsFinished : void 0) != null) {
+    finalization = context.bindingsFinished;
+    context.bindingsFinished = null;
+  }
   if (element || newContextKey || forceSaveContext) {
     (element != null ? element : element = {}).childContext = context;
     elements[node.bindingId != null ? node.bindingId : node.bindingId = ++nodeCount] = element;
@@ -89,6 +94,10 @@ bind = function(context, node, forceSaveContext) {
     bind(context, childNode);
   }
   Twine.count = nodeCount;
+  if (finalization) {
+    context.bindingsFinished = finalization;
+    finalization.bind(context)();
+  }
   return Twine;
 };
 

--- a/dist/twine.js
+++ b/dist/twine.js
@@ -1,5 +1,5 @@
 (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
-var attribute, bind, elements, eventName, fireCustomChangeEvent, getContext, getValue, isKeypath, keypathForKey, keypathRegex, nodeCount, preventDefaultForEvent, refreshElement, refreshQueued, rootContext, rootNode, setValue, setupAttributeBinding, setupEventBinding, stringifyNodeAttributes, valueAttributeForNode, wrapFunctionString, _i, _j, _len, _len1, _ref, _ref1,
+var attribute, bind, currentBindingCallbacks, elements, eventName, fireCustomChangeEvent, getContext, getValue, isKeypath, keypathForKey, keypathRegex, nodeCount, preventDefaultForEvent, refreshElement, refreshQueued, rootContext, rootNode, setValue, setupAttributeBinding, setupEventBinding, stringifyNodeAttributes, valueAttributeForNode, wrapFunctionString, _i, _j, _len, _len1, _ref, _ref1,
   __slice = [].slice;
 
 window.Twine = {};
@@ -17,6 +17,8 @@ keypathRegex = /^[a-z]\w*(\.[a-z]\w*|\[\d+\])*$/i;
 refreshQueued = false;
 
 rootNode = null;
+
+currentBindingCallbacks = null;
 
 Twine.reset = function(newContext, node) {
   var bindings, key, obj, _i, _len, _ref;
@@ -50,8 +52,17 @@ Twine.bind = function(node, context) {
   return bind(context, node, true);
 };
 
+Twine.register = function(callback) {
+  if (currentBindingCallbacks) {
+    return currentBindingCallbacks.push(callback);
+  } else {
+    return callback();
+  }
+};
+
 bind = function(context, node, forceSaveContext) {
-  var binding, childNode, definition, element, finalization, fn, keypath, newContextKey, type, _i, _len, _ref, _ref1;
+  var binding, callback, callbacks, childNode, definition, element, fn, keypath, newContextKey, type, _i, _j, _len, _len1, _ref, _ref1;
+  currentBindingCallbacks = [];
   if (node.bindingId) {
     Twine.unbind(node);
   }
@@ -79,25 +90,22 @@ bind = function(context, node, forceSaveContext) {
     }
     context = getValue(context, keypath) || setValue(context, keypath, {});
   }
-  finalization = null;
-  if ((context != null ? context.bindingsFinished : void 0) != null) {
-    finalization = context.bindingsFinished;
-    context.bindingsFinished = null;
-  }
   if (element || newContextKey || forceSaveContext) {
     (element != null ? element : element = {}).childContext = context;
     elements[node.bindingId != null ? node.bindingId : node.bindingId = ++nodeCount] = element;
   }
+  callbacks = currentBindingCallbacks;
   _ref1 = node.children || [];
   for (_i = 0, _len = _ref1.length; _i < _len; _i++) {
     childNode = _ref1[_i];
     bind(context, childNode);
   }
   Twine.count = nodeCount;
-  if (finalization) {
-    context.bindingsFinished = finalization;
-    finalization.bind(context)();
+  for (_j = 0, _len1 = callbacks.length; _j < _len1; _j++) {
+    callback = callbacks[_j];
+    callback();
   }
+  currentBindingCallbacks = null;
   return Twine;
 };
 

--- a/lib/assets/javascripts/twine.js.coffee
+++ b/lib/assets/javascripts/twine.js.coffee
@@ -48,6 +48,11 @@ bind = (context, node, forceSaveContext) ->
       keypath = keypath.slice(1)
     context = getValue(context, keypath) || setValue(context, keypath, {})
 
+  finalization = null
+  if context?.bindingsFinished?
+    finalization =  context.bindingsFinished
+    context.bindingsFinished = null
+
   if element || newContextKey || forceSaveContext
     (element ?= {}).childContext = context
     elements[node.bindingId ?= ++nodeCount] = element
@@ -59,6 +64,11 @@ bind = (context, node, forceSaveContext) ->
   # As a result, Twine are unsupported within DocumentFragment and SVGElement nodes.
   bind(context, childNode) for childNode in (node.children || [])
   Twine.count = nodeCount
+
+  if finalization
+    context.bindingsFinished = finalization
+    finalization.bind(context)()
+
   Twine
 
 # Queues a refresh of the DOM, batching up calls for the current synchronous block.

--- a/lib/assets/javascripts/twine.js.coffee
+++ b/lib/assets/javascripts/twine.js.coffee
@@ -71,7 +71,7 @@ bind = (context, node, forceSaveContext) ->
   bind(context, childNode) for childNode in (node.children || [])
   Twine.count = nodeCount
 
-  for callback in callbacks
+  for callback in callbacks || []
     callback()
   currentBindingCallbacks = null
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "coffeeify": "~0.7.0",
     "uglify-js": "~2.4.15",
     "browserify": "5.11.1",
+    "pbind": "~0.0.1",
     "testem": "0.6.18"
   }
 }

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -1,3 +1,5 @@
+require('pbind')
+
 suite "Twine", ->
   setupView = (html, context) ->
     rootNode.innerHTML = html

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -418,6 +418,39 @@ suite "Twine", ->
       $(node).click()
       assert.isTrue context.fn.calledOnce
 
+  suite "bindingsFinished", ->
+    test "bindingsFinished is called after a node and its children have completed binding", ->
+      testView = '<div define="{bindingsFinished: function() { this.finished = true }}"></div>'
+      node = setupView(testView, context = {})
+
+      assert.isTrue context.finished
+
+    test "bindingsFinished is only called on the defining node", ->
+      testView = '<div define="{called: 0, innerCalled: 0, bindingsFinished: function() { this.called++ }}"><div define="{bindingsFinished: function() { this.innerCalled++ }}"></div></div>'
+      node = setupView(testView, context = {})
+
+      assert.equal 1, context.called
+      assert.equal 1, context.innerCalled
+
+    test "bindingsFinished with object", ->
+      inner = bindingsFinished: -> this.finished = true
+      testView = "<div context=\"inner\"></div>"
+      setupView(testView, inner: inner)
+
+      assert.isTrue inner.finished
+
+    test "bindingsFinished rebind calls bindingsFinished again", ->
+      inner = bindingsFinished: -> this.finished = true
+      testView = "<div context=\"inner\"></div>"
+      node = setupView(testView, inner: inner)
+
+      assert.isTrue inner.finished
+
+      inner.finished = false
+      Twine.reset(inner, rootNode).bind()
+
+      assert.isTrue inner.finished
+
   suite "reset", ->
     test "should set up the root node", ->
       Twine.reset(context = {}, rootNode)


### PR DESCRIPTION
@BlakeMesdag pointed me to a problem with how I had fixed the initial dirty state for Forms in Shopify and we realized that at the root of the issue was that we didn't have anything to hook onto when the binding for a node was completed (aka the node and its children are bound).

In this PR @BlakeMesdag and I add this functionality `bindingFinished`. What we do is when binding we check if the context has a `bindingFinished` attribute, if it does we pop it off and store it temporarily (this way child nodes don't re-call this). When all the children are bound and we return to the top level where we popped off the function we call it and then re-attach it to the node (this is for re-bindings so it can be re-bound the same way).

We should probably also add a note about this to the readme.

for review
@qq99 @pushrax 
cc @BlakeMesdag 