### PR TITLE
add success as bindable event name

### DIFF
--- a/lib/assets/javascripts/twine.js.coffee
+++ b/lib/assets/javascripts/twine.js.coffee
@@ -310,5 +310,5 @@ setupEventBinding = (eventName) ->
     return teardown: ->
       $(node).off eventName, onEventHandler
 
-for eventName in ['click', 'dblclick', 'mousedown', 'mouseup', 'submit', 'dragenter', 'dragleave', 'dragover', 'drop', 'drag', 'change', 'keypress', 'keydown', 'keyup', 'input', 'error', 'done', 'fail', 'blur', 'focus', 'load']
+for eventName in ['click', 'dblclick', 'mousedown', 'mouseup', 'submit', 'dragenter', 'dragleave', 'dragover', 'drop', 'drag', 'change', 'keypress', 'keydown', 'keyup', 'input', 'error', 'done', 'success', 'fail', 'blur', 'focus', 'load']
   setupEventBinding(eventName)


### PR DESCRIPTION
Adding `success` as a bindable event name.

Note how in `src/shopify/...remote.coffee` at line 16 we listen for `turbograft:remote:always` and then trigger `done` on the initiator. The trigger for `turbograft:remote:always` is set at line 43 in `turbograft/lib/.../remote.coffee` on `loadend`. However, and most importantly, note how the `load` event, which precedes `loadend` triggers page refreshes (but also triggers `turbograft:remote:success`). The issue then, is that if the page refresh causes the initiator element to be removed from the page, then it will never receive the `done` event.

Fortunately, we dispatch `turbograft:remote:success` so if we add `success` to the bindable events, and update remote.coffee in the Shopify code base, such as is done in this PR https://github.com/Shopify/shopify/pull/36834, then we can fix the issue.

@qq99 @kevinhughes27 
cc @maartenvg @celsodantas 
