### PR TITLE
check attribute change should fire  event

### DIFF
--- a/dist/twine.js
+++ b/dist/twine.js
@@ -286,7 +286,7 @@ stringifyNodeAttributes = function(node) {
   result = "";
   while (i < nAttributes) {
     attr = node.attributes.item(i);
-    result += "" + attr.nodeName + "='" + attr.textContent + "'";
+    result += attr.nodeName + "='" + attr.textContent + "'";
     i += 1;
   }
   return result;
@@ -450,7 +450,10 @@ setupAttributeBinding = function(attributeName, bindingName) {
         if (newValue === lastValue) {
           return;
         }
-        return node[attributeName] = lastValue = newValue;
+        node[attributeName] = lastValue = newValue;
+        if (attributeName === 'checked') {
+          return fireCustomChangeEvent(node);
+        }
       }
     };
   };

--- a/lib/assets/javascripts/twine.js.coffee
+++ b/lib/assets/javascripts/twine.js.coffee
@@ -286,6 +286,8 @@ setupAttributeBinding = (attributeName, bindingName) ->
       return if newValue == lastValue
       node[attributeName] = lastValue = newValue
 
+      fireCustomChangeEvent(node) if attributeName == 'checked'
+
 for attribute in ['placeholder', 'checked', 'disabled', 'href', 'title', 'readOnly', 'src']
   setupAttributeBinding(attribute, attribute)
 

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -206,6 +206,17 @@ suite "Twine", ->
       Twine.refreshImmediately()
       assert.isFalse node.checked
 
+    test "should fire bindings:change on check change", ->
+      testView = "<input type=\"checkbox\" bind-checked=\"key\">"
+      node = setupView(testView, context = key: true)
+
+      node.addEventListener('bindings:change', eventSpy = @spy())
+
+      context.key = false
+      Twine.refreshImmediately()
+
+      assert.ok eventSpy.called
+
   suite "bind-placeholder attribute", ->
     test "should set the placeholder attribute", ->
       testView = "<div bind-placeholder=\"key\">"


### PR DESCRIPTION
`bind-check` should fire a change event (`bindings:change`) whenever a `check` happen in the node.

Currently this is not happening, so if you have a node like:

```html
<input bind-checked="publishable.isAlreadyPublished()" type="checkbox">
```
Changing the return value of `publishable.isAlreadyPublished()` will check/uncheck the input but no change event is fired.

I need this to fix a bug in Shopify where changing the checkbox using the binding system is not making the form dirty as it does not get any event from the checkbox node.

@qq99 @nsimmons @pushrax @richardmonette 
