### PR TITLE
add bind-attribute

### DIFF
--- a/lib/assets/javascripts/twine.js.coffee
+++ b/lib/assets/javascripts/twine.js.coffee
@@ -268,6 +268,15 @@ Twine.bindingTypes =
         $(node).toggleClass(key, !!value)
       lastValue = newValue
 
+  'bind-attribute': (node, context, definition) ->
+    fn = wrapFunctionString(definition, '$context,$root', node)
+    lastValue = {}
+    return refresh: ->
+      newValue = fn.call(node, context, rootContext)
+      for key, value of newValue when lastValue[key] != value
+        $(node).attr(key, value)
+      lastValue = newValue
+
   define: (node, context, definition) ->
     fn = wrapFunctionString(definition, '$context,$root', node)
     object = fn.call(node, context, rootContext)

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -196,6 +196,16 @@ suite "Twine", ->
       node = setupView(testView, key: true)
       assert.equal node.className, "cls"
 
+  suite "bind-attribute attribute", ->
+    test "should apply the given attribute when truthy", ->
+      testView = "<div bind-attribute=\"{a: key, b: false, c: 0, d: null, e: undefined}\"></div>"
+      node = setupView(testView, key: true)
+      assert.equal node.getAttribute('a'), 'true'
+      assert.equal node.getAttribute('b'), 'false'
+      assert.equal node.getAttribute('c'), '0'
+      assert.isFalse node.hasAttribute('d')
+      assert.isFalse node.hasAttribute('e')
+
   suite "bind-checked attribute", ->
     test "should set the checked attribute", ->
       testView = "<input type=\"checkbox\" bind-checked=\"key\">"

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -198,13 +198,14 @@ suite "Twine", ->
 
   suite "bind-attribute attribute", ->
     test "should apply the given attribute when truthy", ->
-      testView = "<div bind-attribute=\"{a: key, b: false, c: 0, d: null, e: undefined}\"></div>"
+      testView = "<div bind-attribute=\"{a: key, b: false, c: 0, d: null, e: undefined, f: function() { return true }}\"></div>"
       node = setupView(testView, key: true)
       assert.equal node.getAttribute('a'), 'true'
       assert.equal node.getAttribute('b'), 'false'
       assert.equal node.getAttribute('c'), '0'
       assert.isFalse node.hasAttribute('d')
       assert.isFalse node.hasAttribute('e')
+      assert.equal node.getAttribute('f'), 'true'
 
   suite "bind-checked attribute", ->
     test "should set the checked attribute", ->


### PR DESCRIPTION
Adds `bind-attribute` which allows for using the binding system to toggle attributes on nodes.

@qq99 @pushrax @kristianpd @DrewMartin @maartenvg 