### PR TITLE
Add an init binding

### DIFF
--- a/lib/assets/javascripts/twine.js.coffee
+++ b/lib/assets/javascripts/twine.js.coffee
@@ -286,6 +286,11 @@ Twine.bindingTypes =
     context[key] = value for key, value of object
     return
 
+  eval: (node, context, definition) ->
+    fn = wrapFunctionString(definition, '$context,$root', node)
+    fn.call(node, context, rootContext)
+    return
+
 setupAttributeBinding = (attributeName, bindingName) ->
   booleanAttribute = attributeName in ['checked', 'disabled', 'readOnly']
 

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -354,6 +354,35 @@ suite "Twine", ->
         setupView(testView, context = {})
       , 'Twine error: Unable to create function on DIV node with attributes define=\'{key: \'value\', key2: \'value2\''
 
+  suite "eval attribute", ->
+    test "should call the given code", ->
+      testView = "<span eval='myArray.push(\"stuff\")'></span>"
+
+      setupView(testView, context = {myArray: []})
+
+      assert.deepEqual ["stuff"], context.myArray
+
+    test "should work with define", ->
+      testView = "<div define='{myArray: []}''><span eval='myArray.push(\"stuff\")'></span></div>"
+
+      setupView(testView, context = {})
+
+      assert.deepEqual ["stuff"], context.myArray
+
+    test "should not mix in the result of eval", ->
+      testView = "<div eval='{thing: \"stuff\"}'></div>"
+
+      setupView(testView, context = {})
+
+      assert.isUndefined context.thing
+
+    test "should throw a helpful error if trying to eval improperly", ->
+      testView = "<div define='{myArray: []}'><span eval='myArray.push(\"stuff)'></span></div>"
+
+      assert.throw ->
+        setupView(testView, context = {})
+      , "Twine error: Unable to create function on SPAN node with attributes eval='myArray.push(\"stuff)'"
+
   suite "refresh", ->
     test "should defer calls and refresh once", ->
       setupView("", {})


### PR DESCRIPTION
Adds an `init` binding. It's similar to `define` except its return value is ignored. One place this would be useful is building an array with bindings, since you can't insert something in an array with define unless you do a hack like `define="array.push(value), {}"`. Simpler to do `init="array.push(value)"`

Some places where this would be useful:
https://github.com/Shopify/shopify/blob/71d34193b66dacefd76f857eab79a8dfcb708ce0/app/views/admin/navigation/_next_nav.html.erb#L364
https://github.com/Shopify/shopify/blob/71d34193b66dacefd76f857eab79a8dfcb708ce0/app/views/admin/home/_welcome_carousel.html.erb#L1
https://github.com/Shopify/shopify/blob/71d34193b66dacefd76f857eab79a8dfcb708ce0/app/views/admin/quotes/_add_shipping.html.erb#L20
https://github.com/Shopify/shopify/blob/71d34193b66dacefd76f857eab79a8dfcb708ce0/app/views/admin/settings/checkout_settings/_checkout.html.erb#L2

@Shopify/tnt 