### PR TITLE
Revert "Speed up attribute loop in bind"

### DIFF
--- a/lib/assets/javascripts/twine.js.coffee
+++ b/lib/assets/javascripts/twine.js.coffee
@@ -45,15 +45,12 @@ bind = (context, node, forceSaveContext) ->
   if node.bindingId
     Twine.unbind(node)
 
-  for attribute in node.attributes
-    if binding = Twine.bindingTypes[attribute.name.toLowerCase()]
-      element = {bindings: []} unless element  # Defer allocation to prevent GC pressure
-      fn = binding(node, context, attribute.value, element)
-      element.bindings.push(fn) if fn
-    else if attribute.name == 'context'
-      newContextKey = attribute.value
+  for type, binding of Twine.bindingTypes when definition = node.getAttribute(type)
+    element = {bindings: []} unless element  # Defer allocation to prevent GC pressure
+    fn = binding(node, context, definition, element)
+    element.bindings.push(fn) if fn
 
-  if newContextKey
+  if newContextKey = node.getAttribute('context')
     keypath = keypathForKey(newContextKey)
     if keypath[0] == '$root'
       context = rootContext
@@ -294,7 +291,7 @@ Twine.bindingTypes =
 setupAttributeBinding = (attributeName, bindingName) ->
   booleanAttribute = attributeName in ['checked', 'disabled', 'readOnly']
 
-  Twine.bindingTypes["bind-#{bindingName.toLowerCase()}"] = (node, context, definition) ->
+  Twine.bindingTypes["bind-#{bindingName}"] = (node, context, definition) ->
     fn = wrapFunctionString(definition, '$context,$root', node)
     lastValue = undefined
     return refresh: ->


### PR DESCRIPTION
Reverts Shopify/twine#31

So the speed up had a problem: it processed the attributes in the order they were defined on the node. This means that if a node looks like
```html
<input bind-event-input="valueChanged()" bind="val">
```
then the bind-event-input attribute will be handled before the bind attribute. Which means the event listener on input for bind-event-input  will be triggered before the input event for bind will be triggered. Which means that if valueChanged() tries accessing `this.val` it will actually see the _previous_ value, not the current.

I tried sorting the attributes first but found that it was a bit slower than the original way, and becomes more complicated. We could theoretically do something like try to handle bind before other attributes, but this would lead to code duplicate or having a function that handles the binding of one attribute which is bad because of some garbage collector optimization we've got going on.

Simplest is just to revert.

@Shopify/tnt 