### PR TITLE
Fals-y values remove the attribute in bind-attribute

### DIFF
--- a/lib/assets/javascripts/twine.js.coffee
+++ b/lib/assets/javascripts/twine.js.coffee
@@ -274,7 +274,7 @@ Twine.bindingTypes =
     return refresh: ->
       newValue = fn.call(node, context, rootContext)
       for key, value of newValue when lastValue[key] != value
-        $(node).attr(key, value)
+        $(node).attr(key, value || null)
       lastValue = newValue
 
   define: (node, context, definition) ->

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -198,14 +198,16 @@ suite "Twine", ->
 
   suite "bind-attribute attribute", ->
     test "should apply the given attribute when truthy", ->
-      testView = "<div bind-attribute=\"{a: key, b: false, c: 0, d: null, e: undefined, f: function() { return true }}\"></div>"
+      testView = "<div bind-attribute=\"{a: key, b: false, c: 0, d: null, e: undefined, f: function() { return true }, g: '0', h: 'false'}\"></div>"
       node = setupView(testView, key: true)
       assert.equal node.getAttribute('a'), 'true'
-      assert.equal node.getAttribute('b'), 'false'
-      assert.equal node.getAttribute('c'), '0'
+      assert.isFalse node.hasAttribute('b')
+      assert.isFalse node.hasAttribute('c')
       assert.isFalse node.hasAttribute('d')
       assert.isFalse node.hasAttribute('e')
       assert.equal node.getAttribute('f'), 'true'
+      assert.equal node.getAttribute('g'), '0'
+      assert.equal node.getAttribute('h'), 'false'
 
   suite "bind-checked attribute", ->
     test "should set the checked attribute", ->


### PR DESCRIPTION
Right now if an attribute is bound to a fals-y value (other than null or undefined) then it will have that attribute with the value rendered as a string. For example:
```html
<div bind-attribute="{attr: false}"></div>
```
will result in 
```html
<div attr="false"></div>
```

This is a bit awkward in places where we only care about the presence of an attribute, not the actual value, because ideally we'd use a boolean statement in the logic, but if the boolean statement is false we get something like the above. Instead, any false-y value will get replaced with a null, which causes the attribute to be removed.

@richardmonette 
@Shopify/tnt 