### PR TITLE
Rename Twine.register to Twine.afterBound

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ $(document).ajaxComplete ->
   Twine.refresh()
 ```
 
-## Twine.register
+## Twine.afterBound
 
 Registers a function to be called when the currently binding node and its children have finished binding.
 
@@ -106,7 +106,7 @@ Example:
 ```coffee
   class Foo
     constructor: ->
-      Twine.register ->
+      Twine.afterBound ->
         console.log("done")
 
     # other methods needed in the context

--- a/dist/twine.js
+++ b/dist/twine.js
@@ -52,7 +52,7 @@ Twine.bind = function(node, context) {
   return bind(context, node, true);
 };
 
-Twine.register = function(callback) {
+Twine.afterBound = function(callback) {
   if (currentBindingCallbacks) {
     return currentBindingCallbacks.push(callback);
   } else {

--- a/lib/assets/javascripts/twine.js.coffee
+++ b/lib/assets/javascripts/twine.js.coffee
@@ -34,7 +34,7 @@ Twine.reset = (newContext, node = document.documentElement) ->
 Twine.bind = (node = rootNode, context = Twine.context(node)) ->
   bind(context, node, true)
 
-Twine.register = (callback) ->
+Twine.afterBound = (callback) ->
   if currentBindingCallbacks
     currentBindingCallbacks.push(callback)
   else

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -471,12 +471,12 @@ suite "Twine", ->
       $(node).click()
       assert.isTrue context.fn.calledOnce
 
-  suite "Twine.register", ->
+  suite "Twine.afterBound", ->
     test "callbacks are passed the context they were defined within", ->
       class window.CallbackTestThing
         called: 0
         constructor: ->
-          Twine.register =>
+          Twine.afterBound =>
             @called++
 
       testView = '''
@@ -492,7 +492,7 @@ suite "Twine", ->
 
     test "callbacks can be defined on the rootContext", ->
       called = false
-      Twine.register(-> called = true)
+      Twine.afterBound(-> called = true)
 
       setupView("<div></div>", context = {})
       assert.isTrue called
@@ -502,7 +502,7 @@ suite "Twine", ->
         @called: 0
         called: 0
         constructor: ->
-          Twine.register =>
+          Twine.afterBound =>
             @called++
             @constructor.called++
 
@@ -523,7 +523,7 @@ suite "Twine", ->
       setupView("<div></div>", context = {})
       assert.isFalse called
 
-      Twine.register(-> called = true)
+      Twine.afterBound(-> called = true)
       assert.isTrue called
 
   suite "reset", ->


### PR DESCRIPTION
Twine.register is poorly named and is confusing people about what it actually does. This renames it to afterBound so it's more explicit about what it does.

@qq99 @kristianpd @dfmcphee 