### PR TITLE
Fix example for binding to element attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,12 +233,12 @@ Twine.reset(context).bind().refresh();
 <p>The following DOM attributes can be bound to via:</p>
 
 <ul>
-  <li><code>bind-event-placeholder</code></li>
-  <li><code>bind-event-checked</code></li>
-  <li><code>bind-event-disabled</code></li>
-  <li><code>bind-event-href</code></li>
-  <li><code>bind-event-title</code></li>
-  <li><code>bind-event-readOnly</code></li>
+  <li><code>bind-placeholder</code></li>
+  <li><code>bind-checked</code></li>
+  <li><code>bind-disabled</code></li>
+  <li><code>bind-href</code></li>
+  <li><code>bind-title</code></li>
+  <li><code>bind-readOnly</code></li>
 </ul>
 
 <div class="prepend-pre">


### PR DESCRIPTION
@qq99 

The example shows binding attributes as events but they are not events and don't need `event-`.