### PR TITLE
fixed data attributes

### DIFF
--- a/dist/twine.js
+++ b/dist/twine.js
@@ -20,6 +20,10 @@ rootNode = null;
 
 currentBindingCallbacks = null;
 
+Twine.getAttribute = function(node, attr) {
+  return node.getAttribute("data-" + attr) || node.getAttribute(attr);
+};
+
 Twine.reset = function(newContext, node) {
   var bindings, j, key, len, obj, ref;
   if (node == null) {
@@ -69,7 +73,7 @@ bind = function(context, node, forceSaveContext) {
   ref = Twine.bindingTypes;
   for (type in ref) {
     binding = ref[type];
-    if (!(definition = node.getAttribute("data-" + type) || (node.getAttribute(type)))) {
+    if (!(definition = Twine.getAttribute(node, type))) {
       continue;
     }
     if (!element) {
@@ -82,7 +86,7 @@ bind = function(context, node, forceSaveContext) {
       element.bindings.push(fn);
     }
   }
-  if (newContextKey = node.getAttribute('context') || node.getAttribute('data-context')) {
+  if (newContextKey = Twine.getAttribute(node, 'context')) {
     keypath = keypathForKey(newContextKey);
     if (keypath[0] === '$root') {
       context = rootContext;
@@ -495,7 +499,7 @@ for (j = 0, len = ref.length; j < len; j++) {
 setupAttributeBinding('innerHTML', 'unsafe-html');
 
 preventDefaultForEvent = function(event) {
-  return (event.type === 'submit' || event.currentTarget.nodeName.toLowerCase() === 'a') && event.currentTarget.getAttribute('data-allow-default') !== '1' && event.currentTarget.getAttribute('allow-default') !== '1';
+  return (event.type === 'submit' || event.currentTarget.nodeName.toLowerCase() === 'a') && Twine.getAttribute(event.currentTarget, 'allow-default') !== '1';
 };
 
 setupEventBinding = function(eventName) {

--- a/dist/twine.js
+++ b/dist/twine.js
@@ -1,6 +1,6 @@
 (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
-var attribute, bind, currentBindingCallbacks, elements, eventName, fireCustomChangeEvent, getContext, getValue, isKeypath, keypathForKey, keypathRegex, nodeCount, preventDefaultForEvent, refreshElement, refreshQueued, rootContext, rootNode, setValue, setupAttributeBinding, setupEventBinding, stringifyNodeAttributes, valueAttributeForNode, wrapFunctionString, _i, _j, _len, _len1, _ref, _ref1,
-  __slice = [].slice;
+var attribute, bind, currentBindingCallbacks, elements, eventName, fireCustomChangeEvent, getContext, getValue, isKeypath, j, k, keypathForKey, keypathRegex, len, len1, nodeCount, preventDefaultForEvent, ref, ref1, refreshElement, refreshQueued, rootContext, rootNode, setValue, setupAttributeBinding, setupEventBinding, stringifyNodeAttributes, valueAttributeForNode, wrapFunctionString,
+  slice = [].slice;
 
 window.Twine = {};
 
@@ -21,14 +21,14 @@ rootNode = null;
 currentBindingCallbacks = null;
 
 Twine.reset = function(newContext, node) {
-  var bindings, key, obj, _i, _len, _ref;
+  var bindings, j, key, len, obj, ref;
   if (node == null) {
     node = document.documentElement;
   }
   for (key in elements) {
-    if (bindings = (_ref = elements[key]) != null ? _ref.bindings : void 0) {
-      for (_i = 0, _len = bindings.length; _i < _len; _i++) {
-        obj = bindings[_i];
+    if (bindings = (ref = elements[key]) != null ? ref.bindings : void 0) {
+      for (j = 0, len = bindings.length; j < len; j++) {
+        obj = bindings[j];
         if (obj.teardown) {
           obj.teardown();
         }
@@ -61,15 +61,15 @@ Twine.afterBound = function(callback) {
 };
 
 bind = function(context, node, forceSaveContext) {
-  var binding, callback, callbacks, childNode, definition, element, fn, keypath, newContextKey, type, _i, _j, _len, _len1, _ref, _ref1, _ref2;
+  var binding, callback, callbacks, childNode, definition, element, fn, j, k, keypath, len, len1, newContextKey, ref, ref1, ref2, type;
   currentBindingCallbacks = [];
   if (node.bindingId) {
     Twine.unbind(node);
   }
-  _ref = Twine.bindingTypes;
-  for (type in _ref) {
-    binding = _ref[type];
-    if (!(definition = node.getAttribute(type) || node.getAttribute("data-" + type))) {
+  ref = Twine.bindingTypes;
+  for (type in ref) {
+    binding = ref[type];
+    if (!(definition = node.getAttribute("data-" + type) || (node.getAttribute(type)))) {
       continue;
     }
     if (!element) {
@@ -82,7 +82,7 @@ bind = function(context, node, forceSaveContext) {
       element.bindings.push(fn);
     }
   }
-  if (newContextKey = node.getAttribute('context')) {
+  if (newContextKey = node.getAttribute('context') || node.getAttribute('data-context')) {
     keypath = keypathForKey(newContextKey);
     if (keypath[0] === '$root') {
       context = rootContext;
@@ -95,15 +95,15 @@ bind = function(context, node, forceSaveContext) {
     elements[node.bindingId != null ? node.bindingId : node.bindingId = ++nodeCount] = element;
   }
   callbacks = currentBindingCallbacks;
-  _ref1 = node.children || [];
-  for (_i = 0, _len = _ref1.length; _i < _len; _i++) {
-    childNode = _ref1[_i];
+  ref1 = node.children || [];
+  for (j = 0, len = ref1.length; j < len; j++) {
+    childNode = ref1[j];
     bind(context, childNode);
   }
   Twine.count = nodeCount;
-  _ref2 = callbacks || [];
-  for (_j = 0, _len1 = _ref2.length; _j < _len1; _j++) {
-    callback = _ref2[_j];
+  ref2 = callbacks || [];
+  for (k = 0, len1 = ref2.length; k < len1; k++) {
+    callback = ref2[k];
     callback();
   }
   currentBindingCallbacks = null;
@@ -119,11 +119,11 @@ Twine.refresh = function() {
 };
 
 refreshElement = function(element) {
-  var obj, _i, _len, _ref;
+  var j, len, obj, ref;
   if (element.bindings) {
-    _ref = element.bindings;
-    for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-      obj = _ref[_i];
+    ref = element.bindings;
+    for (j = 0, len = ref.length; j < len; j++) {
+      obj = ref[j];
       if (obj.refresh != null) {
         obj.refresh();
       }
@@ -151,11 +151,11 @@ Twine.change = function(node, bubble) {
 };
 
 Twine.unbind = function(node) {
-  var bindings, childNode, id, obj, _i, _j, _len, _len1, _ref, _ref1;
+  var bindings, childNode, id, j, k, len, len1, obj, ref, ref1;
   if (id = node.bindingId) {
-    if (bindings = (_ref = elements[id]) != null ? _ref.bindings : void 0) {
-      for (_i = 0, _len = bindings.length; _i < _len; _i++) {
-        obj = bindings[_i];
+    if (bindings = (ref = elements[id]) != null ? ref.bindings : void 0) {
+      for (j = 0, len = bindings.length; j < len; j++) {
+        obj = bindings[j];
         if (obj.teardown) {
           obj.teardown();
         }
@@ -164,9 +164,9 @@ Twine.unbind = function(node) {
     delete elements[id];
     delete node.bindingId;
   }
-  _ref1 = node.children || [];
-  for (_j = 0, _len1 = _ref1.length; _j < _len1; _j++) {
-    childNode = _ref1[_j];
+  ref1 = node.children || [];
+  for (k = 0, len1 = ref1.length; k < len1; k++) {
+    childNode = ref1[k];
     Twine.unbind(childNode);
   }
   return this;
@@ -181,7 +181,7 @@ Twine.childContext = function(node) {
 };
 
 getContext = function(node, child) {
-  var context, id, _ref;
+  var context, id, ref;
   while (node) {
     if (node === rootNode) {
       return rootContext;
@@ -193,7 +193,7 @@ getContext = function(node, child) {
       console.warn("Unable to find context; please check that the node is attached to the DOM that Twine has bound, or that bindings have been initiated on this node's DOM");
       return null;
     }
-    if ((id = node.bindingId) && (context = (_ref = elements[id]) != null ? _ref.childContext : void 0)) {
+    if ((id = node.bindingId) && (context = (ref = elements[id]) != null ? ref.childContext : void 0)) {
       return context;
     }
     if (child) {
@@ -203,7 +203,7 @@ getContext = function(node, child) {
 };
 
 Twine.contextKey = function(node, lastContext) {
-  var addKey, context, id, keys, _ref;
+  var addKey, context, id, keys, ref;
   keys = [];
   addKey = function(context) {
     var key, val;
@@ -218,7 +218,7 @@ Twine.contextKey = function(node, lastContext) {
     return lastContext = context;
   };
   while (node && node !== rootNode && (node = node.parentNode)) {
-    if ((id = node.bindingId) && (context = (_ref = elements[id]) != null ? _ref.childContext : void 0)) {
+    if ((id = node.bindingId) && (context = (ref = elements[id]) != null ? ref.childContext : void 0)) {
       addKey(context);
     }
   }
@@ -229,10 +229,10 @@ Twine.contextKey = function(node, lastContext) {
 };
 
 valueAttributeForNode = function(node) {
-  var name, _ref;
+  var name, ref;
   name = node.nodeName.toLowerCase();
   if (name === 'input' || name === 'textarea' || name === 'select') {
-    if ((_ref = node.getAttribute('type')) === 'checkbox' || _ref === 'radio') {
+    if ((ref = node.getAttribute('type')) === 'checkbox' || ref === 'radio') {
       return 'checked';
     } else {
       return 'value';
@@ -243,11 +243,11 @@ valueAttributeForNode = function(node) {
 };
 
 keypathForKey = function(key) {
-  var end, keypath, start, _i, _len, _ref;
+  var end, j, keypath, len, ref, start;
   keypath = [];
-  _ref = key.split('.');
-  for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-    key = _ref[_i];
+  ref = key.split('.');
+  for (j = 0, len = ref.length; j < len; j++) {
+    key = ref[j];
     if ((start = key.indexOf('[')) !== -1) {
       keypath.push(key.substr(0, start));
       key = key.substr(start);
@@ -263,9 +263,9 @@ keypathForKey = function(key) {
 };
 
 getValue = function(object, keypath) {
-  var key, _i, _len;
-  for (_i = 0, _len = keypath.length; _i < _len; _i++) {
-    key = keypath[_i];
+  var j, key, len;
+  for (j = 0, len = keypath.length; j < len; j++) {
+    key = keypath[j];
     if (object != null) {
       object = object[key];
     }
@@ -274,10 +274,10 @@ getValue = function(object, keypath) {
 };
 
 setValue = function(object, keypath, value) {
-  var key, lastKey, _i, _j, _len, _ref;
-  _ref = keypath, keypath = 2 <= _ref.length ? __slice.call(_ref, 0, _i = _ref.length - 1) : (_i = 0, []), lastKey = _ref[_i++];
-  for (_j = 0, _len = keypath.length; _j < _len; _j++) {
-    key = keypath[_j];
+  var j, k, key, lastKey, len, ref;
+  ref = keypath, keypath = 2 <= ref.length ? slice.call(ref, 0, j = ref.length - 1) : (j = 0, []), lastKey = ref[j++];
+  for (k = 0, len = keypath.length; k < len; k++) {
+    key = keypath[k];
     object = object[key] != null ? object[key] : object[key] = {};
   }
   return object[lastKey] = value;
@@ -290,14 +290,14 @@ stringifyNodeAttributes = function(node) {
   result = "";
   while (i < nAttributes) {
     attr = node.attributes.item(i);
-    result += "" + attr.nodeName + "='" + attr.textContent + "'";
+    result += attr.nodeName + "='" + attr.textContent + "'";
     i += 1;
   }
   return result;
 };
 
 wrapFunctionString = function(code, args, node) {
-  var e, keypath;
+  var e, error, keypath;
   if (isKeypath(code) && (keypath = keypathForKey(code))) {
     if (keypath[0] === '$root') {
       return function($context, $root) {
@@ -311,8 +311,8 @@ wrapFunctionString = function(code, args, node) {
   } else {
     try {
       return new Function(args, "with($context) { return " + code + " }");
-    } catch (_error) {
-      e = _error;
+    } catch (error) {
+      e = error;
       throw "Twine error: Unable to create function on " + node.nodeName + " node with attributes " + (stringifyNodeAttributes(node));
     }
   }
@@ -486,24 +486,24 @@ setupAttributeBinding = function(attributeName, bindingName) {
   };
 };
 
-_ref = ['placeholder', 'checked', 'disabled', 'href', 'title', 'readOnly', 'src'];
-for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-  attribute = _ref[_i];
+ref = ['placeholder', 'checked', 'disabled', 'href', 'title', 'readOnly', 'src'];
+for (j = 0, len = ref.length; j < len; j++) {
+  attribute = ref[j];
   setupAttributeBinding(attribute, attribute);
 }
 
 setupAttributeBinding('innerHTML', 'unsafe-html');
 
 preventDefaultForEvent = function(event) {
-  return (event.type === 'submit' || event.currentTarget.nodeName.toLowerCase() === 'a') && event.currentTarget.getAttribute('allow-default') !== '1';
+  return (event.type === 'submit' || event.currentTarget.nodeName.toLowerCase() === 'a') && event.currentTarget.getAttribute('data-allow-default') !== '1' && event.currentTarget.getAttribute('allow-default') !== '1';
 };
 
 setupEventBinding = function(eventName) {
   return Twine.bindingTypes["bind-event-" + eventName] = function(node, context, definition) {
     var onEventHandler;
     onEventHandler = function(event, data) {
-      var discardEvent, _base;
-      discardEvent = typeof (_base = Twine.shouldDiscardEvent)[eventName] === "function" ? _base[eventName](event) : void 0;
+      var base, discardEvent;
+      discardEvent = typeof (base = Twine.shouldDiscardEvent)[eventName] === "function" ? base[eventName](event) : void 0;
       if (discardEvent || preventDefaultForEvent(event)) {
         event.preventDefault();
       }
@@ -522,9 +522,9 @@ setupEventBinding = function(eventName) {
   };
 };
 
-_ref1 = ['click', 'dblclick', 'mouseenter', 'mouseleave', 'mouseover', 'mouseout', 'mousedown', 'mouseup', 'submit', 'dragenter', 'dragleave', 'dragover', 'drop', 'drag', 'change', 'keypress', 'keydown', 'keyup', 'input', 'error', 'done', 'success', 'fail', 'blur', 'focus', 'load'];
-for (_j = 0, _len1 = _ref1.length; _j < _len1; _j++) {
-  eventName = _ref1[_j];
+ref1 = ['click', 'dblclick', 'mouseenter', 'mouseleave', 'mouseover', 'mouseout', 'mousedown', 'mouseup', 'submit', 'dragenter', 'dragleave', 'dragover', 'drop', 'drag', 'change', 'keypress', 'keydown', 'keyup', 'input', 'error', 'done', 'success', 'fail', 'blur', 'focus', 'load'];
+for (k = 0, len1 = ref1.length; k < len1; k++) {
+  eventName = ref1[k];
   setupEventBinding(eventName);
 }
 

--- a/lib/assets/javascripts/twine.js.coffee
+++ b/lib/assets/javascripts/twine.js.coffee
@@ -17,6 +17,9 @@ rootNode = null
 
 currentBindingCallbacks = null
 
+Twine.getAttribute = (node, attr) ->
+  node.getAttribute("data-#{attr}") || node.getAttribute(attr)
+
 # Cleans up all existing bindings and sets the root node and context.
 Twine.reset = (newContext, node = document.documentElement) ->
   for key of elements
@@ -45,12 +48,12 @@ bind = (context, node, forceSaveContext) ->
   if node.bindingId
     Twine.unbind(node)
 
-  for type, binding of Twine.bindingTypes when definition = node.getAttribute("data-#{type}") || (node.getAttribute(type))
+  for type, binding of Twine.bindingTypes when definition = Twine.getAttribute(node, type)
     element = {bindings: []} unless element  # Defer allocation to prevent GC pressure
     fn = binding(node, context, definition, element)
     element.bindings.push(fn) if fn
 
-  if newContextKey = node.getAttribute('context') || node.getAttribute('data-context')
+  if newContextKey = Twine.getAttribute(node, 'context')
     keypath = keypathForKey(newContextKey)
     if keypath[0] == '$root'
       context = rootContext
@@ -312,8 +315,7 @@ setupAttributeBinding('innerHTML', 'unsafe-html')
 
 preventDefaultForEvent = (event) ->
   (event.type == 'submit' || event.currentTarget.nodeName.toLowerCase() == 'a') &&
-  event.currentTarget.getAttribute('data-allow-default') != '1' &&
-  event.currentTarget.getAttribute('allow-default') != '1'
+  Twine.getAttribute(event.currentTarget, 'allow-default') != '1'
 
 setupEventBinding = (eventName) ->
   Twine.bindingTypes["bind-event-#{eventName}"] = (node, context, definition) ->

--- a/lib/assets/javascripts/twine.js.coffee
+++ b/lib/assets/javascripts/twine.js.coffee
@@ -45,12 +45,12 @@ bind = (context, node, forceSaveContext) ->
   if node.bindingId
     Twine.unbind(node)
 
-  for type, binding of Twine.bindingTypes when definition = (node.getAttribute(type) || node.getAttribute("data-#{type}"))
+  for type, binding of Twine.bindingTypes when definition = node.getAttribute("data-#{type}") || (node.getAttribute(type))
     element = {bindings: []} unless element  # Defer allocation to prevent GC pressure
     fn = binding(node, context, definition, element)
     element.bindings.push(fn) if fn
 
-  if newContextKey = node.getAttribute('context')
+  if newContextKey = node.getAttribute('context') || node.getAttribute('data-context')
     keypath = keypathForKey(newContextKey)
     if keypath[0] == '$root'
       context = rootContext
@@ -311,7 +311,9 @@ for attribute in ['placeholder', 'checked', 'disabled', 'href', 'title', 'readOn
 setupAttributeBinding('innerHTML', 'unsafe-html')
 
 preventDefaultForEvent = (event) ->
-  (event.type == 'submit' || event.currentTarget.nodeName.toLowerCase() == 'a') && event.currentTarget.getAttribute('allow-default') != '1'
+  (event.type == 'submit' || event.currentTarget.nodeName.toLowerCase() == 'a') &&
+  event.currentTarget.getAttribute('data-allow-default') != '1' &&
+  event.currentTarget.getAttribute('allow-default') != '1'
 
 setupEventBinding = (eventName) ->
   Twine.bindingTypes["bind-event-#{eventName}"] = (node, context, definition) ->

--- a/lib/twine-rails/version.rb
+++ b/lib/twine-rails/version.rb
@@ -1,3 +1,3 @@
 module TwineRails
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -385,6 +385,47 @@ suite "Twine", ->
         setupView(testView, context = {})
       , "Twine error: Unable to create function on SPAN node with attributes data-eval='myArray.push(\"stuff)'"
 
+  suite "data-allow-default", ->
+    test "should prevent default action for an anchor tag", ->
+      testView = "<a data-bind-event-click=\"fn()\"></a>"
+      event = {type: 'click', preventDefault: @spy()}
+      node = setupView(testView, fn: ->)
+
+      $(node).trigger(event)
+      assert.isTrue event.preventDefault.calledOnce
+
+    test "should allow default action for an anchor tag when set to 1", ->
+      testView = "<a data-bind-event-click=\"fn()\" data-allow-default=\"1\"></a>"
+      event = {type: 'click', preventDefault: @spy()}
+      node = setupView(testView, fn: ->)
+
+      $(node).trigger(event)
+      assert.isFalse event.preventDefault.called
+
+    test "should prevent default action for a submit event", ->
+      testView = "<form action=\"#\" data-bind-event-submit=\"fn()\"></form>"
+      event = {type: 'submit', preventDefault: @spy()}
+      node = setupView(testView, fn: ->)
+
+      $(node).trigger(event)
+      assert.isTrue event.preventDefault.calledOnce
+
+    test "should allow default action for a submit event when set to 1", ->
+      testView = "<form action=\"#\" data-bind-event-submit=\"fn()\" data-allow-default=\"1\"></form>"
+      event = {type: 'submit', preventDefault: @spy()}
+      node = setupView(testView, fn: ->)
+
+      $(node).trigger(event)
+      assert.isFalse event.preventDefault.called
+
+    test "should do nothing unless an anchor tag or submit event", ->
+      testView = "<button data-bind-event-click=\"fn()\" data-allow-default=\"0\"></button>"
+      event = {type: 'click', preventDefault: @spy()}
+      node = setupView(testView, fn: ->)
+
+      $(node).trigger(event)
+      assert.isFalse event.preventDefault.called
+
   suite "data-refresh", ->
     test "should defer calls and refresh once", ->
       setupView("", {})
@@ -963,6 +1004,47 @@ suite "TwineLegacy", ->
       assert.throw ->
         setupView(testView, context = {})
       , "Twine error: Unable to create function on SPAN node with attributes eval='myArray.push(\"stuff)'"
+
+  suite "allow-default", ->
+    test "should prevent default action for an anchor tag", ->
+      testView = "<a bind-event-click=\"fn()\"></a>"
+      event = {type: 'click', preventDefault: @spy()}
+      node = setupView(testView, fn: ->)
+
+      $(node).trigger(event)
+      assert.isTrue event.preventDefault.calledOnce
+
+    test "should allow default action for an anchor tag when set to 1", ->
+      testView = "<a bind-event-click=\"fn()\" allow-default=\"1\"></a>"
+      event = {type: 'click', preventDefault: @spy()}
+      node = setupView(testView, fn: ->)
+
+      $(node).trigger(event)
+      assert.isFalse event.preventDefault.called
+
+    test "should prevent default action for a submit event", ->
+      testView = "<form action=\"#\" bind-event-submit=\"fn()\"></form>"
+      event = {type: 'submit', preventDefault: @spy()}
+      node = setupView(testView, fn: ->)
+
+      $(node).trigger(event)
+      assert.isTrue event.preventDefault.calledOnce
+
+    test "should allow default action for a submit event when set to 1", ->
+      testView = "<form action=\"#\" bind-event-submit=\"fn()\" allow-default=\"1\"></form>"
+      event = {type: 'submit', preventDefault: @spy()}
+      node = setupView(testView, fn: ->)
+
+      $(node).trigger(event)
+      assert.isFalse event.preventDefault.called
+
+    test "should do nothing unless an anchor tag or submit event", ->
+      testView = "<button bind-event-click=\"fn()\" allow-default=\"0\"></button>"
+      event = {type: 'click', preventDefault: @spy()}
+      node = setupView(testView, fn: ->)
+
+      $(node).trigger(event)
+      assert.isFalse event.preventDefault.called
 
   suite "refresh", ->
     test "should defer calls and refresh once", ->

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -16,6 +16,585 @@ suite "Twine", ->
     @clock.tick 100
     rootNode = document.createElement("div")
 
+  suite "data-bind attribute", ->
+    test "should bind basic keypaths", ->
+      testView = "<div data-bind=\"key\"></div>"
+      node = setupView(testView, key: "value")
+      assert.equal node.innerHTML, "value"
+
+    test "should bind compound keypaths", ->
+      testView = "<div data-bind=\"key.nested.more\"></div>"
+      node = setupView(testView, key: {nested: { more: "value"}})
+      assert.equal node.innerHTML, "value"
+
+    test "should bind array accessor keypaths", ->
+      testView = "<input data-bind=\"key[0]\">"
+      node = setupView(testView, context = key: ["value"])
+      assert.equal node.value, "value"
+
+      context.key[0] = "new"
+      Twine.refreshImmediately()
+      assert.equal node.value, "new"
+
+      node.value = "value"
+      triggerEvent node, "change"
+      assert.equal node.value, "value"
+
+    test "should bind 'true' keyword keypaths", ->
+      testView = "<div data-bind=\"true\"></div>"
+      node = setupView(testView, key: "true")
+      assert.equal node.innerHTML, "true"
+
+    test "should bind 'false' keyword keypaths", ->
+      testView = "<div data-bind=\"false\"></div>"
+      node = setupView(testView, key: "false")
+      assert.equal node.innerHTML, "false"
+
+    test "should bind undefined keyword keypath", ->
+      testView = "<div data-bind=\"undefined\"></div>"
+      node = setupView(testView, key: "undefined")
+      assert.equal node.innerHTML, ""
+
+    test "should bind null keyword keypath", ->
+      testView = "<div data-bind=\"null\"></div>"
+      node = setupView(testView, key: "null")
+      assert.equal node.innerHTML, ""
+
+    test "should load data from the DOM if not defined", ->
+      testView = "<div data-bind=\"key.nested\">value</div>"
+      setupView(testView, context = {})
+      assert.equal context.key.nested, "value"
+
+    test "should set the value of input[type=text] elements", ->
+      testView = "<input type=\"text\" data-bind=\"key\">"
+      node = setupView(testView, context = key: "value")
+      assert.equal node.value, "value"
+
+      context.key = "new"
+      Twine.refreshImmediately()
+      assert.equal node.value, "new"
+
+    test "should set the checked value of input[type=checkbox] elements", ->
+      testView = "<input type=\"checkbox\" data-bind=\"key\">"
+      node = setupView(testView, context = key: "value")
+      assert.isTrue node.checked
+
+      context.key = ""
+      Twine.refreshImmediately()
+      assert.isFalse node.checked
+
+    test "should set the checked state of input[type=radio] elements", ->
+      testView = "<input type=\"radio\" data-bind=\"key\" value=\"one\"><input type=\"radio\" data-bind=\"key\" value=\"two\">"
+      setupView(testView, context = key: "two")
+      assert.isFalse rootNode.children[0].checked
+      assert.isTrue rootNode.children[1].checked
+
+      context.key = "one"
+      Twine.refreshImmediately()
+      assert.isTrue rootNode.children[0].checked
+      assert.isFalse rootNode.children[1].checked
+
+    test "should get the value of input[type=radio] elements", ->
+      testView = "<input type=\"radio\" name=\"group\" data-bind=\"key\" value=\"one\">" + "<input type=\"radio\" name=\"group\" data-bind=\"key\" value=\"two\" checked>"
+      setupView(testView, context = {})
+      assert.equal context.key, "two"
+
+      rootNode.children[0].checked = true
+      triggerEvent rootNode.children[0], "change"
+      assert.equal context.key, "one"
+
+    test "should get the selected state of the right child in select elements", ->
+      testView = """
+                  <select data-bind="key">
+                    <option value="one">one</option>
+                    <option value="two" selected>two</option>
+                    <option value="three">three</option>
+                  </select>
+                 """
+
+      setupView(testView, context = {})
+      select = rootNode.children[0]
+      options = select.children
+
+      assert.equal context.key, 'two'
+
+      options[0].selected = true
+      triggerEvent select, 'change'
+      assert.equal context.key, 'one'
+
+      options[2].selected = true
+      triggerEvent select, 'change'
+      assert.equal context.key, 'three'
+
+    test "should set the selected state of the right child in select elements", ->
+      testView = """
+                  <select data-bind="key">
+                    <option value="one">one</option>
+                    <option value="two" selected>two</option>
+                    <option value="three">three</option>
+                  </select>
+                 """
+
+      setupView(testView, context = {})
+      select = rootNode.children[0]
+      options = select.children
+
+      assert.isTrue options[1].selected
+
+      context.key = 'one'
+      Twine.refreshImmediately()
+      assert.isTrue options[0].selected
+
+      context.key = 'three'
+      Twine.refreshImmediately()
+      assert.isTrue options[2].selected
+
+    test "should work with arbitrary javascript", ->
+      testView = "<div data-bind=\"key * 2\"></div>"
+      node = setupView(testView, key: 4)
+      assert.equal node.innerHTML, "8"
+
+    test "should work with arbitrary javascript that looks like a keypath", ->
+      testView = "<div data-bind=\"2.34\"></div>"
+      node = setupView(testView, {})
+      assert.equal node.innerHTML, "2.34"
+
+    test "should escape weird characters", ->
+      testView = "<div data-bind=\"key\"></div>"
+      node = setupView(testView, key: "<script>")
+      assert.equal node.innerHTML, "&lt;script&gt;"
+
+  suite "data-bind-show attribute", ->
+    test "should apply the \"hide\" class when falsy", ->
+      testView = "<div data-bind-show=\"key\"></div>"
+      node = setupView(testView, key: false)
+      assert.equal node.className, "hide"
+
+    test "should apply the \"hide\" class when false", ->
+      testView = "<div data-bind-show=\"false\"></div>"
+      node = setupView(testView, key: false)
+      assert.equal node.className, "hide"
+
+    test "should apply the \"hide\" class when undefined", ->
+      testView = "<div data-bind-show=\"undefined\"></div>"
+      node = setupView(testView, key: false)
+      assert.equal node.className, "hide"
+
+    test "should not apply any class when truthy", ->
+      testView = "<div data-bind-show=\"key\"></div>"
+      node = setupView(testView, key: true)
+      assert.equal node.className, ""
+
+    test "should not apply any class when is 'true'", ->
+      testView = "<div data-bind-show=\"true\"></div>"
+      node = setupView(testView, key: true)
+      assert.equal node.className, ""
+
+  suite "data-bind-class attribute", ->
+    test "should apply the given classes when truthy", ->
+      testView = "<div data-bind-class=\"{cls: key, cls2: false}\"></div>"
+      node = setupView(testView, key: true)
+      assert.equal node.className, "cls"
+
+  suite "data-bind-attribute attribute", ->
+    test "should apply the given attribute when truthy", ->
+      testView = "<div data-bind-attribute=\"{a: key, b: false, c: 0, d: null, e: undefined, f: function() { return true }, g: '0', h: 'false'}\"></div>"
+      node = setupView(testView, key: true)
+      assert.equal node.getAttribute('a'), 'true'
+      assert.isFalse node.hasAttribute('b')
+      assert.isFalse node.hasAttribute('c')
+      assert.isFalse node.hasAttribute('d')
+      assert.isFalse node.hasAttribute('e')
+      assert.equal node.getAttribute('f'), 'true'
+      assert.equal node.getAttribute('g'), '0'
+      assert.equal node.getAttribute('h'), 'false'
+
+  suite "data-bind-checked attribute", ->
+    test "should set the checked attribute", ->
+      testView = "<input type=\"checkbox\" data-bind-checked=\"key\">"
+      node = setupView(testView, context = key: true)
+      assert.isTrue node.checked
+
+      context.key = false
+      Twine.refreshImmediately()
+      assert.isFalse node.checked
+
+    test "should fire bindings:change on check change", ->
+      testView = "<input type=\"checkbox\" data-bind-checked=\"key\">"
+      node = setupView(testView, context = key: true)
+
+      node.addEventListener('bindings:change', eventSpy = @spy())
+
+      context.key = false
+      Twine.refreshImmediately()
+
+      assert.ok eventSpy.called
+
+  suite "data-bind-placeholder attribute", ->
+    test "should set the placeholder attribute", ->
+      testView = "<div data-bind-placeholder=\"key\">"
+      node = setupView(testView, context = key: "val")
+      assert.equal node.placeholder, "val"
+
+      context.key = "other"
+      Twine.refreshImmediately()
+      assert.equal node.placeholder, "other"
+
+  suite "data-bind-readOnly attribute", ->
+    test "should set the readonly attribute", ->
+      testView = "<input type=\"text\" data-bind-readonly=\"key\">"
+      node = setupView(testView, context = key: true)
+      assert.isTrue node.readOnly
+
+      context.key = false
+      Twine.refreshImmediately()
+      assert.isFalse node.readOnly
+
+  suite "data-bind-unsafe-html attribute", ->
+    test "should set the innerHTML of the node", ->
+      testView = "<div data-bind-unsafe-html=\"key\"></div>"
+      node = setupView(testView, key: "&amp;")
+      assert.equal node.innerHTML, "&amp;"
+
+  suite "data-bind-src attribute", ->
+    test "should set the src of the node", ->
+      testView = '<img data-bind-src="key"></div>'
+      node = setupView(testView, key: "image.jpg")
+      assert.match node.src, /\/image\.jpg$/
+
+  suite "data-bind-event-* attribute", ->
+    test "should not run the handler when not allowed", ->
+      testView = "<div data-bind-event-click=\"fn()\"></div>"
+      node = setupView(testView, context = fn: @spy())
+      Twine.shouldDiscardEvent.click = -> true
+
+      $(node).click()
+      assert.equal context.fn.callCount, 0
+      Twine.shouldDiscardEvent = {}
+
+    test "should pass along data if present", ->
+      testView = "<form data-bind-event-submit=\"fn(data)\"></form>"
+      node = setupView(testView, context = fn: @spy())
+      data = {test: 'bla123'}
+
+      $(node).trigger 'submit', data
+
+      assert.isTrue context.fn.calledOnce
+      assert.isTrue context.fn.calledWith(data)
+
+    test "unbind should remove event listener", ->
+      testView = "<div data-bind-event-click=\"fn()\"></div>"
+      node = setupView(testView, context = fn: @spy())
+
+      assert node.bindingId
+      Twine.unbind(node)
+      assert.isUndefined node.bindingId
+
+      $(node).click()
+      assert.equal context.fn.callCount, 0
+
+  suite "data-bind-event-click attribute", ->
+    test "should run the handler on click", ->
+      testView = "<div data-bind-event-click=\"fn()\"></div>"
+      node = setupView(testView, context = fn: @spy())
+
+      $(node).click()
+      assert.isTrue context.fn.calledOnce
+
+  suite "data-bind-event-submit attribute", ->
+    test "should run the handler on submit", ->
+      testView = "<form data-bind-event-submit=\"fn()\"></form>"
+      node = setupView(testView, context = fn: @spy())
+
+      triggerEvent node, "submit"
+      assert.isTrue context.fn.calledOnce
+
+  suite "data-bind-event-change attribute", ->
+    test "should run the handler on change", ->
+      testView = "<input data-bind-event-change=\"fn()\" value=\"old\">"
+      node = setupView(testView, context = fn: @spy())
+      node.value = "new"
+
+      triggerEvent node, "change"
+      assert.isTrue context.fn.calledOnce
+
+  suite "data-bind-event-error attribute", ->
+    test "should run the handler on change", ->
+      testView = "<img src=\"\" data-bind-event-error=\"fn()\">"
+      node = setupView(testView, context = fn: @spy())
+
+      triggerEvent node, "error"
+      assert.isTrue context.fn.calledOnce
+
+  suite "data-bind-event-done attribute", ->
+    test "should run the handler on done event", ->
+      testView = "<form data-bind-event-done=\"fn()\"></form>"
+      node = setupView(testView, context = fn: @spy())
+
+      triggerEvent node, "done"
+      assert.isTrue context.fn.calledOnce
+
+  suite "data-bind-event-fail attribute", ->
+    test "should run the handler on fail event", ->
+      testView = "<form data-bind-event-fail=\"fn()\"></form>"
+      node = setupView(testView, context = fn: @spy())
+
+      triggerEvent node, "fail"
+      assert.isTrue context.fn.calledOnce
+
+  suite "data-define attribute", ->
+    test "should mix in the given keys", ->
+      testView = "<div data-define=\"{key: 'value', key2: 'value2'}\"></div>"
+      setupView(testView, context = {})
+
+      assert.equal context.key, "value"
+      assert.equal context.key2, "value2"
+
+    test "should throw a helpful error if trying to define improperly", ->
+      testView = "<div data-define=\"{key: 'value', key2: 'value2\"></div>"
+      assert.throw ->
+        setupView(testView, context = {})
+      , 'Twine error: Unable to create function on DIV node with attributes data-define=\'{key: \'value\', key2: \'value2\''
+
+  suite "data-eval attribute", ->
+    test "should call the given code", ->
+      testView = "<span data-eval='myArray.push(\"stuff\")'></span>"
+
+      setupView(testView, context = {myArray: []})
+
+      assert.deepEqual ["stuff"], context.myArray
+
+    test "should work with data-define", ->
+      testView = "<div data-define='{myArray: []}''><span data-eval='myArray.push(\"stuff\")'></span></div>"
+
+      setupView(testView, context = {})
+
+      assert.deepEqual ["stuff"], context.myArray
+
+    test "should not mix in the result of eval", ->
+      testView = "<div data-eval='{thing: \"stuff\"}'></div>"
+
+      setupView(testView, context = {})
+
+      assert.isUndefined context.thing
+
+    test "should throw a helpful error if trying to eval improperly", ->
+      testView = "<div data-define='{myArray: []}'><span data-eval='myArray.push(\"stuff)'></span></div>"
+
+      assert.throw ->
+        setupView(testView, context = {})
+      , "Twine error: Unable to create function on SPAN node with attributes data-eval='myArray.push(\"stuff)'"
+
+  suite "data-refresh", ->
+    test "should defer calls and refresh once", ->
+      setupView("", {})
+      @spy(Twine, "refreshImmediately")
+
+      Twine.refresh()
+      Twine.refresh()
+      Twine.refresh()
+      assert.isFalse Twine.refreshImmediately.called
+
+      @clock.tick 100
+      assert.isTrue Twine.refreshImmediately.calledOnce
+
+    test "should happen when a bound element is clicked", ->
+      testView = "<div data-bind-event-click=\"fn()\"></div>"
+      node = setupView(testView, fn: ->)
+      @spy(Twine, "refreshImmediately")
+
+      $(node).click()
+      @clock.tick 100
+      assert.isTrue Twine.refreshImmediately.calledOnce
+
+    test "should happen when a bound input element changes", ->
+      testView = "<input data-bind=\"key\">"
+      node = setupView(testView, {})
+      @spy Twine, "refreshImmediately"
+
+      node.value = "new"
+      triggerEvent node, "change"
+      @clock.tick 100
+      assert.isTrue Twine.refreshImmediately.calledOnce
+
+    test "should not happen if the value did not change", ->
+      testView = "<input data-bind=\"key\">"
+      node = setupView(testView, {})
+      @spy Twine, "refreshImmediately"
+
+      triggerEvent node, "change"
+      @clock.tick 100
+      assert.isFalse Twine.refreshImmediately.called
+
+  suite "data-bind", ->
+    test "should descend contexts", ->
+      inner = key: "value"
+      testView = "<div data-context=\"inner\"><div data-bind=\"key\"></div></div>"
+      node = setupView(testView, inner: inner).children[0]
+
+      assert.equal node.innerHTML, "value"
+      assert.equal Twine.context(node), inner
+
+    test "should create the context if it doesn't exist", ->
+      testView = "<div data-context=\"inner\"><div data-bind=\"key\">value</div></div>"
+      setupView(testView, context = {})
+      assert.equal context.inner.key, "value"
+
+    test "should force the node parameter to have its context stored", ->
+      testView = "<div></div>"
+      node = setupView(testView, context = {})
+
+      Twine.bind(node)
+      assert.equal Twine.context(node), context
+
+    test "should fire custom bindings:change", ->
+      testView = '<input type="text" data-bind="name">'
+      node = setupView(testView, context = {name: "foo"})
+
+      node.addEventListener('bindings:change', eventSpy = @spy())
+
+      context.name = "bar"
+      Twine.refreshImmediately()
+      assert.ok eventSpy.called
+
+    test "should not bind on hidden fields", ->
+      testView = '<input type="hidden" data-bind="name">'
+      node = setupView(testView, context = {name: "foo"})
+
+      node.value = "new"
+      triggerEvent node, "change"
+      assert.equal context.name, "foo"
+
+    test "should not bind on previously binded nodes", ->
+      testView = "<div data-bind-event-click=\"fn()\"></div>"
+      node = setupView(testView, context = fn: @spy())
+      Twine.bind()
+
+      $(node).click()
+      assert.isTrue context.fn.calledOnce
+
+  suite "Twine.afterBound", ->
+    test "callbacks are passed the context they were defined within", ->
+      class window.CallbackTestThing
+        called: 0
+        constructor: ->
+          Twine.afterBound =>
+            @called++
+
+      testView = '''
+      <div id="outerContext" data-context="outer" data-define="{outer: new CallbackTestThing}">
+        <div id="innerContext" data-context="inner" data-define="{inner: new CallbackTestThing}"></div>
+      </div>
+      '''
+
+      node = setupView(testView, context = {})
+
+      assert.equal 1, Twine.context(node).outer.called
+      assert.equal 1, Twine.context(node).outer.inner.called
+
+    test "callbacks can be defined on the rootContext", ->
+      called = false
+      Twine.afterBound(-> called = true)
+
+      setupView("<div></div>", context = {})
+      assert.isTrue called
+
+    test "rebind calls callbacks again", ->
+      class window.CallbackTestThing
+        @called: 0
+        called: 0
+        constructor: ->
+          Twine.afterBound =>
+            @called++
+            @constructor.called++
+
+      testView = '<div data-context="inner" data-define="{inner: new CallbackTestThing}"></div>'
+      node = setupView(testView, inner = {})
+
+      assert.equal 1, Twine.context(node).inner.called
+      assert.equal 1, Twine.context(node).inner.constructor.called
+
+      Twine.bind()
+
+      assert.equal 1, Twine.context(node).inner.called
+      assert.equal 2, Twine.context(node).inner.constructor.called
+
+    test "run the callback even if bindings have finished", ->
+      called = false
+
+      setupView("<div></div>", context = {})
+      assert.isFalse called
+
+      Twine.afterBound(-> called = true)
+      assert.isTrue called
+
+  suite "reset", ->
+    test "should set up the root node", ->
+      Twine.reset(context = {}, rootNode)
+
+      assert.equal rootNode.bindingId, 1
+      assert.equal Twine.context(rootNode), context
+
+    test "should teardown all elements in memory", ->
+      testView = "<div data-bind-event-click=\"fn()\"></div>"
+      node = setupView(testView, context = fn: @spy())
+      Twine.bind(node)
+      Twine.reset({}, rootNode)
+
+      $(node).click()
+      assert.equal context.fn.callCount, 0
+
+  test "context should return the node's context", ->
+    testView = '<div data-context="inner"><div data-context="inner"></div></div>'
+    node = setupView(testView, context = {inner: {inner: {}}})
+
+    assert.equal Twine.context(node), context
+    assert.equal Twine.context(node.firstChild), context.inner
+
+  test "context should return null if the node has no context", ->
+    testView = '<div data-context="inner"><div data-context="inner"></div></div>'
+    rootNode.innerHTML = testView
+    node = rootNode.children[0]
+
+    assert.equal null, Twine.context(node)
+
+  test "childContext should return the node's childrens' context", ->
+    testView = '<div data-context="inner"><div data-context="inner"></div></div>'
+    node = setupView(testView, context = {inner: {inner: {}}})
+
+    assert.equal Twine.childContext(node), context.inner
+    assert.equal Twine.childContext(node.firstChild), context.inner.inner
+
+  test "contextKey should return the key", ->
+    testView = '<div data-context="inner"><div data-context="inner"><div></div></div></div>'
+    node = setupView(testView, context = {inner: {inner: {}}})
+
+    assert.equal Twine.contextKey(node), ''
+    assert.equal Twine.contextKey(node.firstChild), 'inner'
+    assert.equal Twine.contextKey(node.firstChild.firstChild), 'inner.inner'
+
+  test "contextKey should accept an extra context to use as the last key element", ->
+    testView = '<div data-context="inner"><div data-context="inner"><div></div></div></div>'
+    node = setupView(testView, context = {inner: {inner: {}}})
+
+    assert.equal Twine.contextKey(node.firstChild, context.inner.inner), 'inner.inner'
+
+suite "TwineLegacy", ->
+  setupView = (html, context) ->
+    rootNode.innerHTML = html
+    Twine.reset(context, rootNode).bind().refreshImmediately()
+    rootNode.children[0]
+
+  triggerEvent = (node, eventName) ->
+    event = document.createEvent("HTMLEvents")
+    event.initEvent eventName, false, true
+    node.dispatchEvent event
+
+  rootNode = undefined
+  setup ->
+    @clock.tick 100
+    rootNode = document.createElement("div")
+
   suite "bind attribute", ->
     test "should bind basic keypaths", ->
       testView = "<div bind=\"key\"></div>"
@@ -384,108 +963,6 @@ suite "Twine", ->
       assert.throw ->
         setupView(testView, context = {})
       , "Twine error: Unable to create function on SPAN node with attributes eval='myArray.push(\"stuff)'"
-
-  suite "data- attributes", ->
-    test "data-bind should map to bind", ->
-      testView = "<div data-bind=\"key\"></div>"
-      node = setupView(testView, key: "value")
-      assert.equal node.innerHTML, "value"
-
-    test "data-bind-show should map to bind-show", ->
-      testView = "<div data-bind-show=\"key\"></div>"
-      node = setupView(testView, key: false)
-      assert.equal node.className, "hide"
-
-    test "data-bind-class should map to bind-class", ->
-      testView = "<div data-bind-class=\"{cls: key, cls2: false}\"></div>"
-      node = setupView(testView, key: true)
-      assert.equal node.className, "cls"
-
-    test "data-bind-attribute should map to bind-attribute", ->
-      testView = "<div data-bind-attribute=\"{a: key}\"></div>"
-      node = setupView(testView, key: true)
-      assert.equal node.getAttribute('a'), 'true'
-
-    test "data-bind-checked should map to bind-checked", ->
-      testView = "<input type=\"checkbox\" data-bind-checked=\"key\">"
-      node = setupView(testView, context = key: true)
-      assert.isTrue node.checked
-
-    test "data-bind-placeholder should map to bind-placeholder", ->
-      testView = "<div data-bind-placeholder=\"key\">"
-      node = setupView(testView, context = key: "val")
-      assert.equal node.placeholder, "val"
-
-    test "data-bind-readonly should map to bind-readonly", ->
-      testView = "<input type=\"text\" data-bind-readonly=\"key\">"
-      node = setupView(testView, context = key: true)
-      assert.isTrue node.readOnly
-
-    test "data-bind-unsafe-html should map to bind-unsafe-html", ->
-      testView = "<div data-bind-unsafe-html=\"key\"></div>"
-      node = setupView(testView, key: "&amp;")
-      assert.equal node.innerHTML, "&amp;"
-
-    test "data-bind-src should map to bind-src", ->
-      testView = '<img data-bind-src="key"></div>'
-      node = setupView(testView, key: "image.jpg")
-      assert.match node.src, /\/image\.jpg$/
-
-    test "data-bind-event-click should map to bind-event-click", ->
-      testView = "<div data-bind-event-click=\"fn()\"></div>"
-      node = setupView(testView, context = fn: @spy())
-
-      $(node).click()
-      assert.isTrue context.fn.calledOnce
-
-    test "data-bind-event-submit should map to bind-event-submit", ->
-      testView = "<form data-bind-event-submit=\"fn()\"></form>"
-      node = setupView(testView, context = fn: @spy())
-
-      triggerEvent node, "submit"
-      assert.isTrue context.fn.calledOnce
-
-    test "data-bind-event-change should map to bind-event-change", ->
-      testView = "<input data-bind-event-change=\"fn()\" value=\"old\">"
-      node = setupView(testView, context = fn: @spy())
-      node.value = "new"
-
-      triggerEvent node, "change"
-      assert.isTrue context.fn.calledOnce
-
-    test "data-bind-event-error should map to bind-event-error", ->
-      testView = "<img src=\"\" data-bind-event-error=\"fn()\">"
-      node = setupView(testView, context = fn: @spy())
-
-      triggerEvent node, "error"
-      assert.isTrue context.fn.calledOnce
-
-    test "data-bind-event-done should map to bind-event-done", ->
-      testView = "<form bind-event-done=\"fn()\"></form>"
-      node = setupView(testView, context = fn: @spy())
-
-      triggerEvent node, "done"
-      assert.isTrue context.fn.calledOnce
-
-    test "data-bind-event-fail should map to bind-event-fail", ->
-      testView = "<form data-bind-event-fail=\"fn()\"></form>"
-      node = setupView(testView, context = fn: @spy())
-
-      triggerEvent node, "fail"
-      assert.isTrue context.fn.calledOnce
-
-    test "data-define should map to define", ->
-      testView = "<div data-define=\"{key: 'value'}\"></div>"
-      setupView(testView, context = {})
-
-      assert.equal context.key, "value"
-
-    test "data-eval should map to eval", ->
-      testView = "<span data-eval='myArray.push(\"stuff\")'></span>"
-
-      setupView(testView, context = {myArray: []})
-
-      assert.deepEqual ["stuff"], context.myArray
 
   suite "refresh", ->
     test "should defer calls and refresh once", ->


### PR DESCRIPTION
@tylerball noticed that `data-context` wasn’t working. This PR allows `data-` prefixes on `context` and `allow-default`, which were missed last time around, and adds more robust tests for `data-` prefixed attributes.

I noticed there are no tests for `allow-default`; is anybody able to write some that test the intended behaviour? (I could probably come up with one if nobody else is game.)

@Shopify/tnt