### PR TITLE
add bind-prop

### DIFF
--- a/dist/twine.js
+++ b/dist/twine.js
@@ -301,7 +301,7 @@ stringifyNodeAttributes = function(node) {
 };
 
 wrapFunctionString = function(code, args, node) {
-  var e, error, keypath;
+  var e, keypath;
   if (isKeypath(code) && (keypath = keypathForKey(code))) {
     if (keypath[0] === '$root') {
       return function($context, $root) {
@@ -315,8 +315,8 @@ wrapFunctionString = function(code, args, node) {
   } else {
     try {
       return new Function(args, "with($context) { return " + code + " }");
-    } catch (error) {
-      e = error;
+    } catch (_error) {
+      e = _error;
       throw "Twine error: Unable to create function on " + node.nodeName + " node with attributes " + (stringifyNodeAttributes(node));
     }
   }
@@ -442,6 +442,24 @@ Twine.bindingTypes = {
           value = newValue[key];
           if (lastValue[key] !== value) {
             $(node).attr(key, value || null);
+          }
+        }
+        return lastValue = newValue;
+      }
+    };
+  },
+  'bind-prop': function(node, context, definition) {
+    var fn, lastValue;
+    fn = wrapFunctionString(definition, '$context,$root', node);
+    lastValue = {};
+    return {
+      refresh: function() {
+        var key, newValue, value;
+        newValue = fn.call(node, context, rootContext);
+        for (key in newValue) {
+          value = newValue[key];
+          if (lastValue[key] !== value) {
+            node[key] = value;
           }
         }
         return lastValue = newValue;

--- a/lib/assets/javascripts/twine.js.coffee
+++ b/lib/assets/javascripts/twine.js.coffee
@@ -283,6 +283,15 @@ Twine.bindingTypes =
         $(node).attr(key, value || null)
       lastValue = newValue
 
+  'bind-prop': (node, context, definition) ->
+    fn = wrapFunctionString(definition, '$context,$root', node)
+    lastValue = {}
+    return refresh: ->
+      newValue = fn.call(node, context, rootContext)
+      for key, value of newValue when lastValue[key] != value
+        node[key] = value
+      lastValue = newValue
+
   define: (node, context, definition) ->
     fn = wrapFunctionString(definition, '$context,$root', node)
     object = fn.call(node, context, rootContext)

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -196,6 +196,23 @@ suite "Twine", ->
       node = setupView(testView, key: true)
       assert.equal node.className, "cls"
 
+  suite "data-bind-prop attribute", ->
+    test "should apply the given prop when truthy", ->
+      testView = "<div data-bind-prop=\"{a: true_key, b: false, c: 0, d: null, e: undefined, f: string_key}\"></div>"
+      node = setupView(testView, true_key: true, string_key: "yolo")
+      assert.equal node.a, true
+      assert.isTrue node.hasOwnProperty('a')
+      assert.equal node.b, false
+      assert.isTrue node.hasOwnProperty('b')
+      assert.equal node.c, 0
+      assert.isTrue node.hasOwnProperty('c')
+      assert.equal node.d, null
+      assert.isTrue node.hasOwnProperty('d')
+      assert.equal node.e, null
+      assert.isFalse node.hasOwnProperty('e')
+      assert.equal node.f, 'yolo'
+      assert.isTrue node.hasOwnProperty('f')
+
   suite "data-bind-attribute attribute", ->
     test "should apply the given attribute when truthy", ->
       testView = "<div data-bind-attribute=\"{a: key, b: false, c: 0, d: null, e: undefined, f: function() { return true }, g: '0', h: 'false'}\"></div>"


### PR DESCRIPTION
##### Background

Turns out that properties and attributes differ in that an attribute is the initial value whereas the property is the dynamic value.

| $ accessor | return value |
|---|------|
| elem.checked  | (Boolean) Will change with checkbox state |
| $( elem ).prop( "checked" )  |  (Boolean) Will change with checkbox state    |
| elem.getAttribute( "checked" )	  |  (String) Initial state of the checkbox; does not change    |

for more info, see 'Attributes vs. Properties' here: http://api.jquery.com/prop/

##### Why add this?

This would generally be a nice thing to have, but specifically it would allow for binding properties of https://styleguide.myshopify.com/components/form UI components such as `indeterminate` on checkboxes. 

@qq99 @pushrax @maartenvg @katdrobnjakovic 