### PR TITLE
add indeterminate to augment checked

### DIFF
--- a/dist/twine.js
+++ b/dist/twine.js
@@ -301,7 +301,7 @@ stringifyNodeAttributes = function(node) {
 };
 
 wrapFunctionString = function(code, args, node) {
-  var e, error, keypath;
+  var e, keypath;
   if (isKeypath(code) && (keypath = keypathForKey(code))) {
     if (keypath[0] === '$root') {
       return function($context, $root) {
@@ -315,8 +315,8 @@ wrapFunctionString = function(code, args, node) {
   } else {
     try {
       return new Function(args, "with($context) { return " + code + " }");
-    } catch (error) {
-      e = error;
+    } catch (_error) {
+      e = _error;
       throw "Twine error: Unable to create function on " + node.nodeName + " node with attributes " + (stringifyNodeAttributes(node));
     }
   }
@@ -466,7 +466,7 @@ Twine.bindingTypes = {
 
 setupAttributeBinding = function(attributeName, bindingName) {
   var booleanAttribute;
-  booleanAttribute = attributeName === 'checked' || attributeName === 'disabled' || attributeName === 'readOnly';
+  booleanAttribute = attributeName === 'checked' || attributeName === 'indeterminate' || attributeName === 'disabled' || attributeName === 'readOnly';
   return Twine.bindingTypes["bind-" + bindingName] = function(node, context, definition) {
     var fn, lastValue;
     fn = wrapFunctionString(definition, '$context,$root', node);
@@ -490,7 +490,7 @@ setupAttributeBinding = function(attributeName, bindingName) {
   };
 };
 
-ref = ['placeholder', 'checked', 'disabled', 'href', 'title', 'readOnly', 'src'];
+ref = ['placeholder', 'checked', 'indeterminate', 'disabled', 'href', 'title', 'readOnly', 'src'];
 for (j = 0, len = ref.length; j < len; j++) {
   attribute = ref[j];
   setupAttributeBinding(attribute, attribute);

--- a/lib/assets/javascripts/twine.js.coffee
+++ b/lib/assets/javascripts/twine.js.coffee
@@ -295,7 +295,7 @@ Twine.bindingTypes =
     return
 
 setupAttributeBinding = (attributeName, bindingName) ->
-  booleanAttribute = attributeName in ['checked', 'disabled', 'readOnly']
+  booleanAttribute = attributeName in ['checked', 'indeterminate', 'disabled', 'readOnly']
 
   Twine.bindingTypes["bind-#{bindingName}"] = (node, context, definition) ->
     fn = wrapFunctionString(definition, '$context,$root', node)
@@ -308,7 +308,7 @@ setupAttributeBinding = (attributeName, bindingName) ->
 
       fireCustomChangeEvent(node) if attributeName == 'checked'
 
-for attribute in ['placeholder', 'checked', 'disabled', 'href', 'title', 'readOnly', 'src']
+for attribute in ['placeholder', 'checked', 'indeterminate', 'disabled', 'href', 'title', 'readOnly', 'src']
   setupAttributeBinding(attribute, attribute)
 
 setupAttributeBinding('innerHTML', 'unsafe-html')

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -209,6 +209,24 @@ suite "Twine", ->
       assert.equal node.getAttribute('g'), '0'
       assert.equal node.getAttribute('h'), 'false'
 
+  suite "data-bind-indeterminate attribute", ->
+    test "should set the indeterminate attribute", ->
+      testView = "<input type=\"checkbox\" data-bind-indeterminate=\"key\">"
+      node = setupView(testView, context = key: true)
+      assert.isTrue node.indeterminate
+
+      context.key = false
+      Twine.refreshImmediately()
+      assert.isFalse node.indeterminate
+
+      context.key = null
+      Twine.refreshImmediately()
+      assert.isFalse node.indeterminate
+
+      context.key = undefined
+      Twine.refreshImmediately()
+      assert.isFalse node.indeterminate
+
   suite "data-bind-checked attribute", ->
     test "should set the checked attribute", ->
       testView = "<input type=\"checkbox\" data-bind-checked=\"key\">"


### PR DESCRIPTION
Investigated adding `bind-prop` for this https://github.com/Shopify/twine/pull/58, but I think since this is roughly equivalent to `checked` we just add this as another option.

@qq99 @pushrax @maartenvg @katdrobnjakovic @Shopify/tnt 