### PR TITLE
Add binding for innerText

### DIFF
--- a/dist/twine.js
+++ b/dist/twine.js
@@ -498,6 +498,8 @@ for (j = 0, len = ref.length; j < len; j++) {
 
 setupAttributeBinding('innerHTML', 'unsafe-html');
 
+setupAttributeBinding('innerText', 'inner-text');
+
 preventDefaultForEvent = function(event) {
   return (event.type === 'submit' || event.currentTarget.nodeName.toLowerCase() === 'a') && Twine.getAttribute(event.currentTarget, 'allow-default') !== '1';
 };

--- a/lib/assets/javascripts/twine.js.coffee
+++ b/lib/assets/javascripts/twine.js.coffee
@@ -312,6 +312,7 @@ for attribute in ['placeholder', 'checked', 'disabled', 'href', 'title', 'readOn
   setupAttributeBinding(attribute, attribute)
 
 setupAttributeBinding('innerHTML', 'unsafe-html')
+setupAttributeBinding('innerText', 'inner-text')
 
 preventDefaultForEvent = (event) ->
   (event.type == 'submit' || event.currentTarget.nodeName.toLowerCase() == 'a') &&

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -250,11 +250,11 @@ suite "Twine", ->
       Twine.refreshImmediately()
       assert.isFalse node.readOnly
 
-  suite "data-bind-unsafe-html attribute", ->
-    test "should set the innerHTML of the node", ->
-      testView = "<div data-bind-unsafe-html=\"key\"></div>"
-      node = setupView(testView, key: "&amp;")
-      assert.equal node.innerHTML, "&amp;"
+  suite "data-bind-inner-text attribute", ->
+    test "should set the innerText of the node", ->
+      testView = "<div data-bind-inner-text=\"key\"></div>"
+      node = setupView(testView, key: "some text")
+      assert.equal node.innerHTML, "some text"
 
   suite "data-bind-src attribute", ->
     test "should set the src of the node", ->
@@ -875,6 +875,12 @@ suite "TwineLegacy", ->
       testView = "<div bind-unsafe-html=\"key\"></div>"
       node = setupView(testView, key: "&amp;")
       assert.equal node.innerHTML, "&amp;"
+
+  suite "bind-inner-text attribute", ->
+    test "should set the innerText of the node", ->
+      testView = "<div bind-inner-text=\"key\"></div>"
+      node = setupView(testView, key: "some text")
+      assert.equal node.innerHTML, "some text"
 
   suite "bind-src attribute", ->
     test "should set the src of the node", ->

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -250,6 +250,12 @@ suite "Twine", ->
       Twine.refreshImmediately()
       assert.isFalse node.readOnly
 
+  suite "data-bind-unsafe-html attribute", ->
+    test "should set the innerHTML of the node", ->
+      testView = "<div data-bind-unsafe-html=\"key\"></div>"
+      node = setupView(testView, key: "&amp;")
+      assert.equal node.innerHTML, "&amp;"
+
   suite "data-bind-inner-text attribute", ->
     test "should set the innerText of the node", ->
       testView = "<div data-bind-inner-text=\"key\"></div>"


### PR DESCRIPTION
This adds the ability to bind a value to the `innerText` property of a node. The default bind uses `textContent` which can [crash the browser](http://connect.microsoft.com/IE/feedbackdetail/view/851144/assigning-textcontent-crashes-the-browser-tab) in IE when there are too many bindings on a page.

@Shopify/tnt 