### PR TITLE
add paste event

### DIFF
--- a/lib/assets/javascripts/twine.js.coffee
+++ b/lib/assets/javascripts/twine.js.coffee
@@ -333,5 +333,7 @@ setupEventBinding = (eventName) ->
     return teardown: ->
       $(node).off eventName, onEventHandler
 
-for eventName in ['click', 'dblclick', 'mouseenter', 'mouseleave', 'mouseover', 'mouseout', 'mousedown', 'mouseup', 'submit', 'dragenter', 'dragleave', 'dragover', 'drop', 'drag', 'change', 'keypress', 'keydown', 'keyup', 'input', 'error', 'done', 'success', 'fail', 'blur', 'focus', 'load', 'paste']
+for eventName in ['click', 'dblclick', 'mouseenter', 'mouseleave', 'mouseover', 'mouseout', 'mousedown', 'mouseup',
+  'submit', 'dragenter', 'dragleave', 'dragover', 'drop', 'drag', 'change', 'keypress', 'keydown', 'keyup', 'input',
+  'error', 'done', 'success', 'fail', 'blur', 'focus', 'load', 'paste']
   setupEventBinding(eventName)

--- a/lib/assets/javascripts/twine.js.coffee
+++ b/lib/assets/javascripts/twine.js.coffee
@@ -333,5 +333,5 @@ setupEventBinding = (eventName) ->
     return teardown: ->
       $(node).off eventName, onEventHandler
 
-for eventName in ['click', 'dblclick', 'mouseenter', 'mouseleave', 'mouseover', 'mouseout', 'mousedown', 'mouseup', 'submit', 'dragenter', 'dragleave', 'dragover', 'drop', 'drag', 'change', 'keypress', 'keydown', 'keyup', 'input', 'error', 'done', 'success', 'fail', 'blur', 'focus', 'load']
+for eventName in ['click', 'dblclick', 'mouseenter', 'mouseleave', 'mouseover', 'mouseout', 'mousedown', 'mouseup', 'submit', 'dragenter', 'dragleave', 'dragover', 'drop', 'drag', 'change', 'keypress', 'keydown', 'keyup', 'input', 'error', 'done', 'success', 'fail', 'blur', 'focus', 'load', 'paste']
   setupEventBinding(eventName)

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -931,6 +931,14 @@ suite "TwineLegacy", ->
       $(node).click()
       assert.equal context.fn.callCount, 0
 
+  suite "bind-event-paste attribute", ->
+    test "should run the handler on paste", ->
+      testView = "<div bind-event-paste=\"fn()\"></div>"
+      node = setupView(testView, context = fn: @spy())
+
+      $(node).trigger 'paste'
+      assert.isTrue context.fn.calledOnce
+
   suite "bind-event-click attribute", ->
     test "should run the handler on click", ->
       testView = "<div bind-event-click=\"fn()\"></div>"


### PR DESCRIPTION
Adds the `paste` event so it can be used as `bind_event_paste`, along the same lines as the venerable `bind_event_click`.

browser support looks OK: http://caniuse.com/#search=paste

We need this in the admin for textfields which should trigger changes when merchants paste value, specifically for the multi select product picker on drafts and transfers. 

@nwtn @qq99 cc @katdrobnjakovic @maartenvg 