### PR TITLE
bump to 0.1.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,49 +1,70 @@
 PATH
   remote: .
   specs:
-    twine-rails (0.1.6)
+    twine-rails (0.1.7)
       coffee-rails
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (4.0.2)
-      activesupport (= 4.0.2)
-      builder (~> 3.1.0)
-      erubis (~> 2.7.0)
-      rack (~> 1.5.2)
+    actionpack (4.2.6)
+      actionview (= 4.2.6)
+      activesupport (= 4.2.6)
+      rack (~> 1.6)
       rack-test (~> 0.6.2)
-    activesupport (4.0.2)
-      i18n (~> 0.6, >= 0.6.4)
-      minitest (~> 4.2)
-      multi_json (~> 1.3)
-      thread_safe (~> 0.1)
-      tzinfo (~> 0.3.37)
-    builder (3.1.4)
-    coffee-rails (4.0.1)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (4.2.6)
+      activesupport (= 4.2.6)
+      builder (~> 3.1)
+      erubis (~> 2.7.0)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    activesupport (4.2.6)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    builder (3.2.2)
+    coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
-      railties (>= 4.0.0, < 5.0)
+      railties (>= 4.0.0, < 5.1.x)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
-    coffee-script-source (1.9.1.1)
+    coffee-script-source (1.10.0)
     erubis (2.7.0)
     execjs (2.6.0)
     i18n (0.7.0)
-    minitest (4.7.5)
-    multi_json (1.11.2)
-    rack (1.5.5)
+    json (1.8.3)
+    loofah (2.0.3)
+      nokogiri (>= 1.5.9)
+    mini_portile2 (2.0.0)
+    minitest (5.8.4)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
+    rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
-    railties (4.0.2)
-      actionpack (= 4.0.2)
-      activesupport (= 4.0.2)
+    rails-deprecated_sanitizer (1.0.3)
+      activesupport (>= 4.2.0.alpha)
+    rails-dom-testing (1.0.7)
+      activesupport (>= 4.2.0.beta, < 5.0)
+      nokogiri (~> 1.6.0)
+      rails-deprecated_sanitizer (>= 1.0.1)
+    rails-html-sanitizer (1.0.3)
+      loofah (~> 2.0)
+    railties (4.2.6)
+      actionpack (= 4.2.6)
+      activesupport (= 4.2.6)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.3.2)
     thor (0.19.1)
     thread_safe (0.3.5)
-    tzinfo (0.3.44)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
@@ -52,3 +73,6 @@ DEPENDENCIES
   bundler
   rake
   twine-rails!
+
+BUNDLED WITH
+   1.11.2

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "twine",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "homepage": "https://github.com/Shopify/twine",
   "authors": [
     "Shopify Inc"

--- a/lib/twine-rails/version.rb
+++ b/lib/twine-rails/version.rb
@@ -1,3 +1,3 @@
 module TwineRails
-  VERSION = '0.1.6'
+  VERSION = '0.1.7'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twine",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "A minimalistic 2-way binding system",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes an inadvertent downgrade in activesupport and actionpack verisons, see https://github.com/Shopify/twine/commit/0ce97f679daa9680d96c00227297e5eef167d042#diff-e79a60dc6b85309ae70a6ea8261eaf95R10

@celsodantas @maartenvg @qq99 cc @Shopify/tnt 