### PR TITLE
Add railties as an explicit dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     twine-rails (0.1.7)
       coffee-rails
+      railties
 
 GEM
   remote: https://rubygems.org/

--- a/lib/twine-rails.rb
+++ b/lib/twine-rails.rb
@@ -1,5 +1,4 @@
 require "rails"
-require "active_support"
 
 require "twine-rails/version"
 

--- a/twine-rails.gemspec
+++ b/twine-rails.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "coffee-rails"
+  spec.add_dependency "railties"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
This gem is defining a Engine so it should have an explicity dependency in railties. It was working before because coffee-rails depends in railties but this may change in the future version of coffee-rails and it will break the gem.

Review @richardmonette