### PR TITLE
Improve allow-default behavior

### DIFF
--- a/dist/twine.js
+++ b/dist/twine.js
@@ -473,7 +473,8 @@
     }
     setupAttributeBinding('innerHTML', 'unsafe-html');
     preventDefaultForEvent = function(event) {
-      return (event.type === 'submit' || event.currentTarget.nodeName.toLowerCase() === 'a') && Twine.getAttribute(event.currentTarget, 'allow-default') !== '1';
+      var ref1;
+      return (event.type === 'submit' || event.currentTarget.nodeName.toLowerCase() === 'a') && ((ref1 = Twine.getAttribute(event.currentTarget, 'allow-default')) === 'false' || ref1 === false || ref1 === 0 || ref1 === (void 0) || ref1 === null);
     };
     setupEventBinding = function(eventName) {
       return Twine.bindingTypes["bind-event-" + eventName] = function(node, context, definition) {

--- a/lib/assets/javascripts/twine.coffee
+++ b/lib/assets/javascripts/twine.coffee
@@ -323,7 +323,7 @@
 
   preventDefaultForEvent = (event) ->
     (event.type == 'submit' || event.currentTarget.nodeName.toLowerCase() == 'a') &&
-    Twine.getAttribute(event.currentTarget, 'allow-default') != '1'
+    Twine.getAttribute(event.currentTarget, 'allow-default') in ['false', false, 0, undefined, null]
 
   setupEventBinding = (eventName) ->
     Twine.bindingTypes["bind-event-#{eventName}"] = (node, context, definition) ->

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -1040,8 +1040,32 @@ suite "TwineLegacy", ->
       $(node).trigger(event)
       assert.isTrue event.preventDefault.calledOnce
 
-    test "should allow default action for an anchor tag when set to 1", ->
+    test "should allow default action for an anchor tag when set to true", ->
+      testView = "<a bind-event-click=\"fn()\" allow-default=\"true\"></a>"
+      event = {type: 'click', preventDefault: @spy()}
+      node = setupView(testView, fn: ->)
+
+      $(node).trigger(event)
+      assert.isFalse event.preventDefault.called
+
+    test "should allow default action for an anchor tag when set to anything but false", ->
       testView = "<a bind-event-click=\"fn()\" allow-default=\"1\"></a>"
+      event = {type: 'click', preventDefault: @spy()}
+      node = setupView(testView, fn: ->)
+
+      $(node).trigger(event)
+      assert.isFalse event.preventDefault.called
+
+    test "should prevent default action for anchor tag when set to false", ->
+      testView = "<a bind-event-click=\"fn()\" allow-default=\"false\"></a>"
+      event = {type: 'click', preventDefault: @spy()}
+      node = setupView(testView, fn: ->)
+
+      $(node).trigger(event)
+      assert.isTrue event.preventDefault.called
+
+    test "should allow default action when allow-default is present", ->
+      testView = "<a bind-event-click=\"fn()\" allow-default></a>"
       event = {type: 'click', preventDefault: @spy()}
       node = setupView(testView, fn: ->)
 
@@ -1056,13 +1080,29 @@ suite "TwineLegacy", ->
       $(node).trigger(event)
       assert.isTrue event.preventDefault.calledOnce
 
-    test "should allow default action for a submit event when set to 1", ->
+    test "should allow default action for a submit event when set to true", ->
+      testView = "<form action=\"#\" bind-event-submit=\"fn()\" allow-default=\"true\"></form>"
+      event = {type: 'submit', preventDefault: @spy()}
+      node = setupView(testView, fn: ->)
+
+      $(node).trigger(event)
+      assert.isFalse event.preventDefault.called
+
+    test "should allow default action for a submit event when set to anything but false", ->
       testView = "<form action=\"#\" bind-event-submit=\"fn()\" allow-default=\"1\"></form>"
       event = {type: 'submit', preventDefault: @spy()}
       node = setupView(testView, fn: ->)
 
       $(node).trigger(event)
       assert.isFalse event.preventDefault.called
+
+    test "should prevent default action for a submit event when set to false", ->
+      testView = "<form action=\"#\" bind-event-submit=\"fn()\" allow-default=\"false\"></form>"
+      event = {type: 'submit', preventDefault: @spy()}
+      node = setupView(testView, fn: ->)
+
+      $(node).trigger(event)
+      assert.isTrue event.preventDefault.calledOnce
 
     test "should do nothing unless an anchor tag or submit event", ->
       testView = "<button bind-event-click=\"fn()\" allow-default=\"0\"></button>"


### PR DESCRIPTION
Currently, `allow-default` checks for a value of `'1'` explicitly, which can be a bit confusing. This PR changes its functionality to work more like the `checked` attribute - as long as it is present and has any value besides `'false'`, it will allow default.

cc: @dan-menard @beefchimi @Shopify/tnt 