### PR TITLE
Bump nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,10 +40,12 @@ GEM
     json (1.8.3)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
-    mini_portile2 (2.0.0)
+    mini_portile2 (2.1.0)
     minitest (5.8.4)
-    nokogiri (1.6.7.2)
-      mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.6.8)
+      mini_portile2 (~> 2.1.0)
+      pkg-config (~> 1.1.7)
+    pkg-config (1.1.7)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -75,4 +77,4 @@ DEPENDENCIES
   twine-rails!
 
 BUNDLED WITH
-   1.11.2
+   1.12.5


### PR DESCRIPTION
Bumping nokogiri to 1.6.8 in `Gemfile.lock` due to [Denial of service or RCE from libxml2 and libxslt](https://github.com/sparklemotion/nokogiri/issues/1473).

@Shopify/tnt 