### PR TITLE
define-array and using the array index implicitly

### DIFF
--- a/dist/twine.js
+++ b/dist/twine.js
@@ -62,17 +62,19 @@
       }
     };
     bind = function(context, node, indexes, forceSaveContext) {
-      var binding, callback, callbacks, childNode, defineArrayAttr, definition, element, fn, j, k, key, keypath, len, len1, newContextKey, newIndexes, ref, ref1, ref2, ref3, type, value;
+      var binding, callback, callbacks, childNode, defineArrayAttr, definition, element, fn, j, k, key, keypath, len, len1, newContextKey, newIndexes, ref, ref1, ref2, type, value;
       currentBindingCallbacks = [];
       if (node.bindingId) {
         Twine.unbind(node);
       }
       if (defineArrayAttr = Twine.getAttribute(node, 'define-array')) {
         newIndexes = defineArray(node, context, defineArrayAttr);
-        ref = indexes || {};
-        for (key in ref) {
-          value = ref[key];
-          if (newIndexes[key] == null) {
+        if (indexes == null) {
+          indexes = {};
+        }
+        for (key in indexes) {
+          value = indexes[key];
+          if (!newIndexes.hasOwnProperty(key)) {
             newIndexes[key] = value;
           }
         }
@@ -80,9 +82,9 @@
         element = findOrCreateElementForNode(node);
         element.indexes = indexes;
       }
-      ref1 = Twine.bindingTypes;
-      for (type in ref1) {
-        binding = ref1[type];
+      ref = Twine.bindingTypes;
+      for (type in ref) {
+        binding = ref[type];
         if (!(definition = Twine.getAttribute(node, type))) {
           continue;
         }
@@ -109,21 +111,22 @@
       if (element || newContextKey || forceSaveContext) {
         element = findOrCreateElementForNode(node);
         element.childContext = context;
-        if (element.indexes == null) {
-          element.indexes = indexes;
+        if (indexes != null) {
+          if (element.indexes == null) {
+            element.indexes = indexes;
+          }
         }
-        elements[node.bindingId != null ? node.bindingId : node.bindingId = ++nodeCount] = element;
       }
       callbacks = currentBindingCallbacks;
-      ref2 = node.children || [];
-      for (j = 0, len = ref2.length; j < len; j++) {
-        childNode = ref2[j];
+      ref1 = node.children || [];
+      for (j = 0, len = ref1.length; j < len; j++) {
+        childNode = ref1[j];
         bind(context, childNode, newContextKey != null ? null : indexes);
       }
       Twine.count = nodeCount;
-      ref3 = callbacks || [];
-      for (k = 0, len1 = ref3.length; k < len1; k++) {
-        callback = ref3[k];
+      ref2 = callbacks || [];
+      for (k = 0, len1 = ref2.length; k < len1; k++) {
+        callback = ref2[k];
         callback();
       }
       currentBindingCallbacks = null;

--- a/dist/twine.js
+++ b/dist/twine.js
@@ -10,7 +10,7 @@
       return root.Twine = factory();
     }
   })(this, function() {
-    var Twine, attribute, bind, currentBindingCallbacks, elements, eventName, fireCustomChangeEvent, getContext, getValue, isKeypath, j, k, keypathForKey, keypathRegex, len, len1, nodeCount, preventDefaultForEvent, ref, ref1, refreshElement, refreshQueued, registry, requiresRegistry, rootContext, rootNode, setValue, setupAttributeBinding, setupEventBinding, stringifyNodeAttributes, valueAttributeForNode, wrapFunctionString;
+    var Twine, arrayPointersForNode, attribute, bind, currentBindingCallbacks, defineArray, elements, eventName, findOrCreateElementForNode, fireCustomChangeEvent, getContext, getIndexesForElement, getValue, isKeypath, j, k, keyWithArrayIndex, keypathForKey, keypathRegex, len, len1, nodeCount, nodeHasArrayIndexes, preventDefaultForEvent, ref, ref1, refreshElement, refreshQueued, registry, requiresRegistry, rootContext, rootNode, setValue, setupAttributeBinding, setupEventBinding, stringifyNodeAttributes, valueAttributeForNode, wrapFunctionString;
     Twine = {};
     Twine.shouldDiscardEvent = {};
     elements = {};
@@ -52,7 +52,7 @@
       if (context == null) {
         context = Twine.context(node);
       }
-      return bind(context, node, true);
+      return bind(context, node, getIndexesForElement(node), true);
     };
     Twine.afterBound = function(callback) {
       if (currentBindingCallbacks) {
@@ -61,22 +61,37 @@
         return callback();
       }
     };
-    bind = function(context, node, forceSaveContext) {
-      var binding, callback, callbacks, childNode, definition, element, fn, j, k, keypath, len, len1, newContextKey, ref, ref1, ref2, type;
+    bind = function(context, node, indexes, forceSaveContext) {
+      var binding, callback, callbacks, childNode, defineArrayAttr, definition, element, fn, j, k, key, keypath, len, len1, newContextKey, newIndexes, ref, ref1, ref2, ref3, type, value;
       currentBindingCallbacks = [];
       if (node.bindingId) {
         Twine.unbind(node);
       }
-      ref = Twine.bindingTypes;
-      for (type in ref) {
-        binding = ref[type];
+      if (defineArrayAttr = Twine.getAttribute(node, 'define-array')) {
+        newIndexes = defineArray(node, context, defineArrayAttr);
+        ref = indexes || {};
+        for (key in ref) {
+          value = ref[key];
+          if (newIndexes[key] == null) {
+            newIndexes[key] = value;
+          }
+        }
+        indexes = newIndexes;
+        element = findOrCreateElementForNode(node);
+        element.indexes = indexes;
+      }
+      ref1 = Twine.bindingTypes;
+      for (type in ref1) {
+        binding = ref1[type];
         if (!(definition = Twine.getAttribute(node, type))) {
           continue;
         }
-        if (!element) {
-          element = {
-            bindings: []
-          };
+        element = findOrCreateElementForNode(node);
+        if (element.bindings == null) {
+          element.bindings = [];
+        }
+        if (element.indexes == null) {
+          element.indexes = indexes;
         }
         fn = binding(node, context, definition, element);
         if (fn) {
@@ -84,7 +99,7 @@
         }
       }
       if (newContextKey = Twine.getAttribute(node, 'context')) {
-        keypath = keypathForKey(newContextKey);
+        keypath = keypathForKey(node, newContextKey);
         if (keypath[0] === '$root') {
           context = rootContext;
           keypath = keypath.slice(1);
@@ -92,23 +107,37 @@
         context = getValue(context, keypath) || setValue(context, keypath, {});
       }
       if (element || newContextKey || forceSaveContext) {
-        (element != null ? element : element = {}).childContext = context;
+        element = findOrCreateElementForNode(node);
+        element.childContext = context;
+        if (element.indexes == null) {
+          element.indexes = indexes;
+        }
         elements[node.bindingId != null ? node.bindingId : node.bindingId = ++nodeCount] = element;
       }
       callbacks = currentBindingCallbacks;
-      ref1 = node.children || [];
-      for (j = 0, len = ref1.length; j < len; j++) {
-        childNode = ref1[j];
-        bind(context, childNode);
+      ref2 = node.children || [];
+      for (j = 0, len = ref2.length; j < len; j++) {
+        childNode = ref2[j];
+        bind(context, childNode, newContextKey != null ? null : indexes);
       }
       Twine.count = nodeCount;
-      ref2 = callbacks || [];
-      for (k = 0, len1 = ref2.length; k < len1; k++) {
-        callback = ref2[k];
+      ref3 = callbacks || [];
+      for (k = 0, len1 = ref3.length; k < len1; k++) {
+        callback = ref3[k];
         callback();
       }
       currentBindingCallbacks = null;
       return Twine;
+    };
+    findOrCreateElementForNode = function(node) {
+      var name1;
+      if (node.bindingId == null) {
+        node.bindingId = ++nodeCount;
+      }
+      if (elements[name1 = node.bindingId] == null) {
+        elements[name1] = {};
+      }
+      return elements[node.bindingId];
     };
     Twine.refresh = function() {
       if (refreshQueued) {
@@ -201,6 +230,16 @@
         }
       }
     };
+    getIndexesForElement = function(node) {
+      var firstContext, id, ref;
+      firstContext = null;
+      while (node) {
+        if (id = node.bindingId) {
+          return (ref = elements[id]) != null ? ref.indexes : void 0;
+        }
+        node = node.parentNode;
+      }
+    };
     Twine.contextKey = function(node, lastContext) {
       var addKey, context, id, keys, ref;
       keys = [];
@@ -239,24 +278,41 @@
         return 'textContent';
       }
     };
-    keypathForKey = function(key) {
-      var end, j, keypath, len, ref, start;
+    keypathForKey = function(node, key) {
+      var end, i, j, keypath, len, ref, start;
       keypath = [];
       ref = key.split('.');
-      for (j = 0, len = ref.length; j < len; j++) {
-        key = ref[j];
+      for (i = j = 0, len = ref.length; j < len; i = ++j) {
+        key = ref[i];
         if ((start = key.indexOf('[')) !== -1) {
-          keypath.push(key.substr(0, start));
+          if (i === 0) {
+            keypath.push.apply(keypath, keyWithArrayIndex(key.substr(0, start), node));
+          } else {
+            keypath.push(key.substr(0, start));
+          }
           key = key.substr(start);
           while ((end = key.indexOf(']')) !== -1) {
             keypath.push(parseInt(key.substr(1, end), 10));
             key = key.substr(end + 1);
           }
         } else {
-          keypath.push(key);
+          if (i === 0) {
+            keypath.push.apply(keypath, keyWithArrayIndex(key, node));
+          } else {
+            keypath.push(key);
+          }
         }
       }
       return keypath;
+    };
+    keyWithArrayIndex = function(key, node) {
+      var index, ref, ref1;
+      index = (ref = elements[node.bindingId]) != null ? (ref1 = ref.indexes) != null ? ref1[key] : void 0 : void 0;
+      if (index != null) {
+        return [key, index];
+      } else {
+        return [key];
+      }
     };
     getValue = function(object, keypath) {
       var j, key, len;
@@ -291,7 +347,7 @@
     };
     wrapFunctionString = function(code, args, node) {
       var e, error, keypath;
-      if (isKeypath(code) && (keypath = keypathForKey(code))) {
+      if (isKeypath(code) && (keypath = keypathForKey(node, code))) {
         if (keypath[0] === '$root') {
           return function($context, $root) {
             return getValue($root, keypath);
@@ -303,6 +359,9 @@
         }
       } else {
         code = "return " + code;
+        if (nodeHasArrayIndexes(node)) {
+          code = "with($arrayPointers) { " + code + " }";
+        }
         if (requiresRegistry(args)) {
           code = "with($registry) { " + code + " }";
         }
@@ -316,6 +375,29 @@
     };
     requiresRegistry = function(args) {
       return /\$registry/.test(args);
+    };
+    nodeHasArrayIndexes = function(node) {
+      var ref;
+      if (node.bindingId == null) {
+        return;
+      }
+      return !(((ref = elements[node.bindingId]) != null ? ref.indexes : void 0) == null);
+    };
+    arrayPointersForNode = function(node, context) {
+      var index, indexes, key, ref, result;
+      if (node.bindingId == null) {
+        return {};
+      }
+      indexes = (ref = elements[node.bindingId]) != null ? ref.indexes : void 0;
+      if (indexes == null) {
+        return {};
+      }
+      result = {};
+      for (key in indexes) {
+        index = indexes[key];
+        result[key] = context[key][index];
+      }
+      return result;
     };
     isKeypath = function(value) {
       return (value !== 'true' && value !== 'false' && value !== 'null' && value !== 'undefined') && keypathRegex.test(value);
@@ -334,10 +416,10 @@
         lastValue = void 0;
         teardown = void 0;
         checkedValueType = node.getAttribute('type') === 'radio';
-        fn = wrapFunctionString(definition, '$context,$root', node);
+        fn = wrapFunctionString(definition, '$context,$root,$arrayPointers', node);
         refresh = function() {
           var newValue;
-          newValue = fn.call(node, context, rootContext);
+          newValue = fn.call(node, context, rootContext, arrayPointersForNode(node, context));
           if (newValue === lastValue) {
             return;
           }
@@ -363,7 +445,7 @@
             return setValue(context, keypath, node[valueAttribute]);
           }
         };
-        keypath = keypathForKey(definition);
+        keypath = keypathForKey(node, definition);
         twoWayBinding = valueAttribute !== 'textContent' && node.type !== 'hidden';
         if (keypath[0] === '$root') {
           context = rootContext;
@@ -392,12 +474,12 @@
       },
       'bind-show': function(node, context, definition) {
         var fn, lastValue;
-        fn = wrapFunctionString(definition, '$context,$root', node);
+        fn = wrapFunctionString(definition, '$context,$root,$arrayPointers', node);
         lastValue = void 0;
         return {
           refresh: function() {
             var newValue;
-            newValue = !fn.call(node, context, rootContext);
+            newValue = !fn.call(node, context, rootContext, arrayPointersForNode(node, context));
             if (newValue === lastValue) {
               return;
             }
@@ -407,12 +489,12 @@
       },
       'bind-class': function(node, context, definition) {
         var fn, lastValue;
-        fn = wrapFunctionString(definition, '$context,$root', node);
+        fn = wrapFunctionString(definition, '$context,$root,$arrayPointers', node);
         lastValue = {};
         return {
           refresh: function() {
             var key, newValue, value;
-            newValue = fn.call(node, context, rootContext);
+            newValue = fn.call(node, context, rootContext, arrayPointersForNode(node, context));
             for (key in newValue) {
               value = newValue[key];
               if (!lastValue[key] !== !value) {
@@ -425,12 +507,12 @@
       },
       'bind-attribute': function(node, context, definition) {
         var fn, lastValue;
-        fn = wrapFunctionString(definition, '$context,$root', node);
+        fn = wrapFunctionString(definition, '$context,$root,$arrayPointers', node);
         lastValue = {};
         return {
           refresh: function() {
             var key, newValue, value;
-            newValue = fn.call(node, context, rootContext);
+            newValue = fn.call(node, context, rootContext, arrayPointersForNode(node, context));
             for (key in newValue) {
               value = newValue[key];
               if (lastValue[key] !== value) {
@@ -443,8 +525,8 @@
       },
       define: function(node, context, definition) {
         var fn, key, object, value;
-        fn = wrapFunctionString(definition, '$context,$root,$registry', node);
-        object = fn.call(node, context, rootContext, registry);
+        fn = wrapFunctionString(definition, '$context,$root,$registry,$arrayPointers', node);
+        object = fn.call(node, context, rootContext, registry, arrayPointersForNode(node, context));
         for (key in object) {
           value = object[key];
           context[key] = value;
@@ -452,21 +534,39 @@
       },
       "eval": function(node, context, definition) {
         var fn;
-        fn = wrapFunctionString(definition, '$context,$root,$registry', node);
-        fn.call(node, context, rootContext, registry);
+        fn = wrapFunctionString(definition, '$context,$root,$registry,$arrayPointers', node);
+        fn.call(node, context, rootContext, registry, arrayPointersForNode(node, context));
       }
+    };
+    defineArray = function(node, context, definition) {
+      var fn, indexes, key, object, value;
+      fn = wrapFunctionString(definition, '$context,$root', node);
+      object = fn.call(node, context, rootContext);
+      indexes = {};
+      for (key in object) {
+        value = object[key];
+        if (context[key] == null) {
+          context[key] = [];
+        }
+        if (!(context[key] instanceof Array)) {
+          throw "Twine error: expected '" + key + "' to be an array";
+        }
+        indexes[key] = context[key].length;
+        context[key].push(value);
+      }
+      return indexes;
     };
     setupAttributeBinding = function(attributeName, bindingName) {
       var booleanAttribute;
       booleanAttribute = attributeName === 'checked' || attributeName === 'indeterminate' || attributeName === 'disabled' || attributeName === 'readOnly';
       return Twine.bindingTypes["bind-" + bindingName] = function(node, context, definition) {
         var fn, lastValue;
-        fn = wrapFunctionString(definition, '$context,$root', node);
+        fn = wrapFunctionString(definition, '$context,$root,$arrayPointers', node);
         lastValue = void 0;
         return {
           refresh: function() {
             var newValue;
-            newValue = fn.call(node, context, rootContext);
+            newValue = fn.call(node, context, rootContext, arrayPointersForNode(node, context));
             if (booleanAttribute) {
               newValue = !!newValue;
             }
@@ -503,7 +603,7 @@
           if (discardEvent) {
             return;
           }
-          wrapFunctionString(definition, '$context,$root,event,data', node).call(node, context, rootContext, event, data);
+          wrapFunctionString(definition, '$context,$root,$arrayPointers,event,data', node).call(node, context, rootContext, arrayPointersForNode(node, context), event, data);
           return Twine.refreshImmediately();
         };
         $(node).on(eventName, onEventHandler);

--- a/lib/assets/javascripts/twine.coffee
+++ b/lib/assets/javascripts/twine.coffee
@@ -46,7 +46,7 @@
     this
 
   Twine.bind = (node = rootNode, context = Twine.context(node)) ->
-    bind(context, node, true)
+    bind(context, node, getIndexesForElement(node), true)
 
   Twine.afterBound = (callback) ->
     if currentBindingCallbacks
@@ -54,25 +54,39 @@
     else
       callback()
 
-  bind = (context, node, forceSaveContext) ->
+  bind = (context, node, indexes, forceSaveContext) ->
     currentBindingCallbacks = []
     if node.bindingId
       Twine.unbind(node)
 
+    if defineArrayAttr = Twine.getAttribute(node, 'define-array')
+      newIndexes = defineArray(node, context, defineArrayAttr)
+      for key, value of indexes || {} when !newIndexes[key]?
+        newIndexes[key] = value
+      indexes = newIndexes
+      # register the element early because subsequent bindings on the same node might need to make use of the index
+      element = findOrCreateElementForNode(node)
+      element.indexes = indexes
+
     for type, binding of Twine.bindingTypes when definition = Twine.getAttribute(node, type)
-      element = {bindings: []} unless element  # Defer allocation to prevent GC pressure
+      element = findOrCreateElementForNode(node)
+      element.bindings ?= []
+      element.indexes ?= indexes
+
       fn = binding(node, context, definition, element)
       element.bindings.push(fn) if fn
 
     if newContextKey = Twine.getAttribute(node, 'context')
-      keypath = keypathForKey(newContextKey)
+      keypath = keypathForKey(node, newContextKey)
       if keypath[0] == '$root'
         context = rootContext
         keypath = keypath.slice(1)
       context = getValue(context, keypath) || setValue(context, keypath, {})
 
     if element || newContextKey || forceSaveContext
-      (element ?= {}).childContext = context
+      element = findOrCreateElementForNode(node)
+      element.childContext = context
+      element.indexes ?= indexes
       elements[node.bindingId ?= ++nodeCount] = element
 
     callbacks = currentBindingCallbacks
@@ -82,7 +96,7 @@
     # we stop traversing that subtree.
     # https://developer.mozilla.org/en-US/docs/Web/API/ParentNode.children
     # As a result, Twine are unsupported within DocumentFragment and SVGElement nodes.
-    bind(context, childNode) for childNode in (node.children || [])
+    bind(context, childNode, if newContextKey? then null else indexes) for childNode in (node.children || [])
     Twine.count = nodeCount
 
     for callback in callbacks || []
@@ -90,6 +104,11 @@
     currentBindingCallbacks = null
 
     Twine
+
+  findOrCreateElementForNode = (node) ->
+    node.bindingId ?= ++nodeCount
+    elements[node.bindingId] ?= {}
+    elements[node.bindingId]
 
   # Queues a refresh of the DOM, batching up calls for the current synchronous block.
   Twine.refresh = ->
@@ -147,6 +166,13 @@
         return context
       node = node.parentNode if child
 
+  getIndexesForElement = (node) ->
+    firstContext = null
+    while node
+      return elements[id]?.indexes if id = node.bindingId
+      node = node.parentNode
+    return
+
   # Returns the fully qualified key for a node's context
   Twine.contextKey = (node, lastContext) ->
     keys = []
@@ -169,19 +195,32 @@
     else
       'textContent'
 
-  keypathForKey = (key) ->
+  keypathForKey = (node, key) ->
     keypath = []
-    for key in key.split('.')
+    for key, i in key.split('.')
       if (start = key.indexOf('[')) != -1
-        keypath.push(key.substr(0, start))
+        if i == 0
+          keypath.push(keyWithArrayIndex(key.substr(0, start), node)...)
+        else
+          keypath.push(key.substr(0, start))
         key = key.substr(start)
 
         while (end = key.indexOf(']')) != -1
           keypath.push(parseInt(key.substr(1, end), 10))
           key = key.substr(end + 1)
       else
-        keypath.push(key)
+        if i == 0
+          keypath.push(keyWithArrayIndex(key, node)...)
+        else
+          keypath.push(key)
     keypath
+
+  keyWithArrayIndex = (key, node) ->
+    index = elements[node.bindingId]?.indexes?[key]
+    if index?
+      [key, index]
+    else
+      [key]
 
   getValue = (object, keypath) ->
     object = object[key] for key in keypath when object?
@@ -204,13 +243,14 @@
     result
 
   wrapFunctionString = (code, args, node) ->
-    if isKeypath(code) && keypath = keypathForKey(code)
+    if isKeypath(code) && keypath = keypathForKey(node, code)
       if keypath[0] == '$root'
         ($context, $root) -> getValue($root, keypath)
       else
         ($context, $root) -> getValue($context, keypath)
     else
       code = "return #{code}"
+      code = "with($arrayPointers) { #{code} }" if nodeHasArrayIndexes(node)
       code = "with($registry) { #{code} }" if requiresRegistry(args)
       try
         new Function(args, "with($context) { #{code} }")
@@ -218,6 +258,20 @@
         throw "Twine error: Unable to create function on #{node.nodeName} node with attributes #{stringifyNodeAttributes(node)}"
 
   requiresRegistry = (args) -> /\$registry/.test(args)
+
+  nodeHasArrayIndexes = (node) ->
+    return unless node.bindingId?
+    !!elements[node.bindingId]?.indexes?
+
+  arrayPointersForNode = (node, context) ->
+    return {} unless node.bindingId?
+    indexes = elements[node.bindingId]?.indexes
+    return {} unless !!indexes?
+
+    result = {}
+    for key, index of indexes
+      result[key] = context[key][index]
+    result
 
   isKeypath = (value) ->
     value not in ['true', 'false', 'null', 'undefined'] and keypathRegex.test(value)
@@ -236,10 +290,10 @@
 
       # Radio buttons only set the value to the node value if checked.
       checkedValueType = node.getAttribute('type') == 'radio'
-      fn = wrapFunctionString(definition, '$context,$root', node)
+      fn = wrapFunctionString(definition, '$context,$root,$arrayPointers', node)
 
       refresh = ->
-        newValue = fn.call(node, context, rootContext)
+        newValue = fn.call(node, context, rootContext, arrayPointersForNode(node, context))
         return if newValue == lastValue # return if we can and avoid a DOM operation
 
         lastValue = newValue
@@ -257,7 +311,7 @@
         else
           setValue(context, keypath, node[valueAttribute])
 
-      keypath = keypathForKey(definition)
+      keypath = keypathForKey(node, definition)
       twoWayBinding = valueAttribute != 'textContent' && node.type != 'hidden'
 
       if keypath[0] == '$root'
@@ -279,50 +333,65 @@
       {refresh, teardown}
 
     'bind-show': (node, context, definition) ->
-      fn = wrapFunctionString(definition, '$context,$root', node)
+      fn = wrapFunctionString(definition, '$context,$root,$arrayPointers', node)
       lastValue = undefined
       return refresh: ->
-        newValue = !fn.call(node, context, rootContext)
+        newValue = !fn.call(node, context, rootContext, arrayPointersForNode(node, context))
         return if newValue == lastValue
         $(node).toggleClass('hide', lastValue = newValue)
 
     'bind-class': (node, context, definition) ->
-      fn = wrapFunctionString(definition, '$context,$root', node)
+      fn = wrapFunctionString(definition, '$context,$root,$arrayPointers', node)
       lastValue = {}
       return refresh: ->
-        newValue = fn.call(node, context, rootContext)
+        newValue = fn.call(node, context, rootContext, arrayPointersForNode(node, context))
         for key, value of newValue when !lastValue[key] != !value
           $(node).toggleClass(key, !!value)
         lastValue = newValue
 
     'bind-attribute': (node, context, definition) ->
-      fn = wrapFunctionString(definition, '$context,$root', node)
+      fn = wrapFunctionString(definition, '$context,$root,$arrayPointers', node)
       lastValue = {}
       return refresh: ->
-        newValue = fn.call(node, context, rootContext)
+        newValue = fn.call(node, context, rootContext, arrayPointersForNode(node, context))
         for key, value of newValue when lastValue[key] != value
           $(node).attr(key, value || null)
         lastValue = newValue
 
     define: (node, context, definition) ->
-      fn = wrapFunctionString(definition, '$context,$root,$registry', node)
-      object = fn.call(node, context, rootContext, registry)
+      fn = wrapFunctionString(definition, '$context,$root,$registry,$arrayPointers', node)
+      object = fn.call(node, context, rootContext, registry, arrayPointersForNode(node, context))
       context[key] = value for key, value of object
       return
 
     eval: (node, context, definition) ->
-      fn = wrapFunctionString(definition, '$context,$root,$registry', node)
-      fn.call(node, context, rootContext, registry)
+      fn = wrapFunctionString(definition, '$context,$root,$registry,$arrayPointers', node)
+      fn.call(node, context, rootContext, registry, arrayPointersForNode(node, context))
       return
+
+  defineArray = (node, context, definition) ->
+    fn = wrapFunctionString(definition, '$context,$root', node)
+    object = fn.call(node, context, rootContext)
+
+    indexes = {}
+
+    for key, value of object
+      context[key] ?= []
+      throw "Twine error: expected '#{key}' to be an array" unless context[key] instanceof Array
+
+      indexes[key] = context[key].length
+      context[key].push(value)
+
+    indexes
 
   setupAttributeBinding = (attributeName, bindingName) ->
     booleanAttribute = attributeName in ['checked', 'indeterminate', 'disabled', 'readOnly']
 
     Twine.bindingTypes["bind-#{bindingName}"] = (node, context, definition) ->
-      fn = wrapFunctionString(definition, '$context,$root', node)
+      fn = wrapFunctionString(definition, '$context,$root,$arrayPointers', node)
       lastValue = undefined
       return refresh: ->
-        newValue = fn.call(node, context, rootContext)
+        newValue = fn.call(node, context, rootContext, arrayPointersForNode(node, context))
         newValue = !!newValue if booleanAttribute
         return if newValue == lastValue
         node[attributeName] = lastValue = newValue
@@ -347,7 +416,7 @@
 
         return if discardEvent
 
-        wrapFunctionString(definition, '$context,$root,event,data', node).call(node, context, rootContext, event, data)
+        wrapFunctionString(definition, '$context,$root,$arrayPointers,event,data', node).call(node, context, rootContext, arrayPointersForNode(node, context), event, data)
         Twine.refreshImmediately()
       $(node).on eventName, onEventHandler
 

--- a/lib/assets/javascripts/twine.coffee
+++ b/lib/assets/javascripts/twine.coffee
@@ -61,7 +61,8 @@
 
     if defineArrayAttr = Twine.getAttribute(node, 'define-array')
       newIndexes = defineArray(node, context, defineArrayAttr)
-      for key, value of indexes || {} when !newIndexes[key]?
+      indexes ?= {}
+      for key, value of indexes when !newIndexes.hasOwnProperty(key)
         newIndexes[key] = value
       indexes = newIndexes
       # register the element early because subsequent bindings on the same node might need to make use of the index
@@ -86,8 +87,7 @@
     if element || newContextKey || forceSaveContext
       element = findOrCreateElementForNode(node)
       element.childContext = context
-      element.indexes ?= indexes
-      elements[node.bindingId ?= ++nodeCount] = element
+      element.indexes ?= indexes if indexes?
 
     callbacks = currentBindingCallbacks
 
@@ -171,7 +171,6 @@
     while node
       return elements[id]?.indexes if id = node.bindingId
       node = node.parentNode
-    return
 
   # Returns the fully qualified key for a node's context
   Twine.contextKey = (node, lastContext) ->
@@ -266,7 +265,7 @@
   arrayPointersForNode = (node, context) ->
     return {} unless node.bindingId?
     indexes = elements[node.bindingId]?.indexes
-    return {} unless !!indexes?
+    return {} unless indexes?
 
     result = {}
     for key, index of indexes


### PR DESCRIPTION
Implementation of https://github.com/Shopify/twine/issues/73

This lets you use `define-array` (or `data-define-array`) similar to define, except it stores the returned values in an array and will push new values to the end. We also store some metadata about array indexes behind the scenes to know which elements correspond to which iterations of an array. Every element (that has bindings) have the same array indexes of its parent, with any new indexes as well. When a new context is entered the nodes inside of it start with a fresh set of array indexes as well, unable to see the array indexes on nodes outside of the current context.
For example:
```html
<div data-define-array="{key: {value: 5, foo: function(){ return 12; }}}">
  <div data-define-array="{nested: {value: 50}}">
    <span bind="key.value">5</span> <!-- key[0].value -->
    <span bind="key.value">12</span> <!-- key[0].foo() -->
    <span bind="nested.value">50</span> <!-- nested[0].value -->
  </div>
  <div data-define-array="{nested: {value: 75}}">
    <span bind="key.value">5</span> <!-- key[0].value -->
    <span bind="key.value">12</span> <!-- key[0].foo() -->
    <span bind="nested.value">75</span> <!-- nested[1].value -->
  </div>
</div>
<div data-define-array="{key: {value: 10, foo: function(){ return 99; }}}">
  <div data-define-array="{nested: {value: 100}}">
    <span bind="key.value">10</span> <!-- key[1].value -->
    <span bind="key.value">99</span> <!-- key[1].foo() -->
    <span bind="nested.value">100</span> <!-- nested[2].value -->
  </div>
  <div data-define-array="{nested: {value: 125}}">
    <span bind="key.value">10</span> <!-- key[1].value -->
    <span bind="key.value">99</span> <!-- key[1].foo() -->
    <span bind="nested.value">125</span> <!-- nested[3].value -->
  </div>
</div>
<div data-define-array="{key: {value: 42}}" context="key"> <!-- key[2] -->
  <!-- has no indexes available -->
  <span bind="value">42</span>
</div>
```

This takes two main changes:
* when building the keypath for a binding, which is used for getting and setting simple values, where it would be `["nested", "value"]` for `nested.value`, instead it becomes `["nested", 0, "value"]` (or whatever the correct array index is, pulled from the node itself). This will only happen for the first key in the keypath because that's the potential array on the context and everything else is nested within the context and not created with `define-array`, at least not on the element being evaluated. (you could have a `define-array` -> `context` -> `define-array` but the outer node wouldn't have access to the array indexes on the inner `define-array`)
* when the binding does not resolve to a keypath, so basically when it's a function call, we create a hash of objects inside the array(s) and use it as the innermost `with` expression, inside of the `with($context)`, so that these take precedence. Effectively it does something like this:
```js
with({key: [1, 2, 3]}) {
  with({key: 1}) { // Or {key: 2}, or {key: 3} depending on what the index is for this node in the array `key` 
    return // Code here
  }
}
```

@pushrax @Shopify/tnt 