### PR TITLE
Bump to 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Twine is available on bower via `bower install twine` if that is your preference
 
 Twine comes as `dist/twine.js` and `dist/twine.min.js` in this repo and in the bower package.
 
-Twine is also available as a gem.  In your Gemfile, add `gem 'twine-rails'` and include it in your `application.js` manifest via `//= require twine`
+Twine is also available as a gem. In your Gemfile, add `gem 'twine-rails'` and include it in your `application.js` manifest via `//= require twine`
+
+AMD, CommonJS and Browser global (using UMD) are also supported.
 
 ## Usage
 
@@ -127,6 +129,24 @@ Example:
   Twine.shouldDiscardEvent.click = (event) ->
     $target = $(event.target)
     $target.hasClass('disabled')
+```
+
+## Twine.register
+
+Lets you add constructors, modules, functions, etc to Twine that are not globally available. This means you can keep your classes etc
+as local variables and Twine will find them for you within `define`s & `eval`s.
+
+```coffee
+  # local_class.coffee
+
+  class LocalClass
+    # ...
+
+  Twine.register('LocalClass', LocalClass)
+```
+
+```html
+  <div define="{localClass: new LocalClass()}"></div>
 ```
 
 ## Dev Console

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "twine",
-  "version": "0.1.7",
+  "version": "1.0.0",
   "homepage": "https://github.com/Shopify/twine",
   "authors": [
     "Shopify Inc"

--- a/lib/twine-rails/version.rb
+++ b/lib/twine-rails/version.rb
@@ -1,3 +1,3 @@
 module TwineRails
-  VERSION = '0.1.7'
+  VERSION = '1.0.0'
 end

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
   "name": "twine",
-  "version": "0.1.7",
+  "version": "1.0.0",
   "description": "A minimalistic 2-way binding system",
-  "main": "index.js",
+  "main": "dist/twine.js",
   "scripts": {
     "test": "node_modules/.bin/testem"
   },
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/Shopify/twine.git"


### PR DESCRIPTION
Let's bump up Twine version to 1.0.0 and start using it through npm instead.

We should now start using `require('twine')` or `import Twine from 'twine'`.

@Shopify/tnt @Shopify/admin-fed 