### PR TITLE
Bind performance

### DIFF
--- a/dist/twine.js
+++ b/dist/twine.js
@@ -10,7 +10,7 @@
       return root.Twine = factory();
     }
   })(this, function() {
-    var Twine, arrayPointersForNode, attribute, bind, currentBindingCallbacks, defineArray, elements, eventName, findOrCreateElementForNode, fireCustomChangeEvent, getContext, getIndexesForElement, getValue, isKeypath, j, k, keyWithArrayIndex, keypathForKey, keypathRegex, len, len1, nodeArrayIndexes, nodeCount, preventDefaultForEvent, ref, ref1, refreshElement, refreshQueued, registry, requiresRegistry, rootContext, rootNode, setValue, setupEventBinding, setupPropertyBinding, stringifyNodeAttributes, valuePropertyForNode, wrapFunctionString;
+    var Twine, arrayPointersForNode, attribute, bind, currentBindingCallbacks, defineArray, elements, eventName, findOrCreateElementForNode, fireCustomChangeEvent, getContext, getIndexesForElement, getValue, isDataAttribute, isKeypath, j, k, keyWithArrayIndex, keypathForKey, keypathRegex, len, len1, nodeArrayIndexes, nodeCount, preventDefaultForEvent, ref, ref1, refreshElement, refreshQueued, registry, requiresRegistry, rootContext, rootNode, setValue, setupEventBinding, setupPropertyBinding, stringifyNodeAttributes, valuePropertyForNode, wrapFunctionString;
     Twine = {};
     Twine.shouldDiscardEvent = {};
     elements = {};
@@ -88,10 +88,9 @@
       for (j = 0, len = ref.length; j < len; j++) {
         attribute = ref[j];
         type = attribute.name;
-        if (type.slice(0, 5) === 'data-') {
+        if (isDataAttribute(type)) {
           type = type.slice(5);
         }
-        definition = attribute.value;
         constructor = Twine.bindingTypes[type];
         if (!constructor) {
           continue;
@@ -99,16 +98,11 @@
         if (bindingConstructors == null) {
           bindingConstructors = [];
         }
+        definition = attribute.value;
         if (type === 'bind') {
-          bindingConstructors.unshift({
-            constructor: constructor,
-            definition: definition
-          });
+          bindingConstructors.unshift([constructor, definition]);
         } else {
-          bindingConstructors.push({
-            constructor: constructor,
-            definition: definition
-          });
+          bindingConstructors.push([constructor, definition]);
         }
       }
       if (bindingConstructors) {
@@ -122,7 +116,7 @@
           element.indexes = indexes;
         }
         for (k = 0, len1 = bindingConstructors.length; k < len1; k++) {
-          ref1 = bindingConstructors[k], constructor = ref1.constructor, definition = ref1.definition;
+          ref1 = bindingConstructors[k], constructor = ref1[0], definition = ref1[1];
           binding = constructor(node, context, definition, element);
           if (binding) {
             element.bindings.push(binding);
@@ -419,6 +413,9 @@
     };
     isKeypath = function(value) {
       return (value !== 'true' && value !== 'false' && value !== 'null' && value !== 'undefined') && keypathRegex.test(value);
+    };
+    isDataAttribute = function(value) {
+      return value[0] === 'd' && value[1] === 'a' && value[2] === 't' && value[3] === 'a' && value[4] === '-';
     };
     fireCustomChangeEvent = function(node) {
       var event;

--- a/dist/twine.js
+++ b/dist/twine.js
@@ -62,7 +62,7 @@
       }
     };
     bind = function(context, node, indexes, forceSaveContext) {
-      var binding, callback, callbacks, childNode, defineArrayAttr, definition, element, fn, j, k, key, keypath, len, len1, newContextKey, newIndexes, ref, ref1, ref2, type, value;
+      var callback, callbacks, childNode, defineArrayAttr, element, j, k, key, keypath, len, len1, newContextKey, newIndexes, ref, ref1, value;
       currentBindingCallbacks = [];
       if (node.bindingId) {
         Twine.unbind(node);
@@ -82,24 +82,29 @@
         element = findOrCreateElementForNode(node);
         element.indexes = indexes;
       }
-      ref = Twine.bindingTypes;
-      for (type in ref) {
-        binding = ref[type];
-        if (!(definition = Twine.getAttribute(node, type))) {
-          continue;
+      element = findOrCreateElementForNode(node);
+      if (element.bindings == null) {
+        element.bindings = [];
+      }
+      if (element.indexes == null) {
+        element.indexes = indexes;
+      }
+      Array.prototype.slice.call(node.attributes).forEach(function(attribute) {
+        var binding, definition, fn, type;
+        type = attribute.name;
+        if (type.slice(0, 5) === 'data-') {
+          type = type.slice(5);
         }
-        element = findOrCreateElementForNode(node);
-        if (element.bindings == null) {
-          element.bindings = [];
-        }
-        if (element.indexes == null) {
-          element.indexes = indexes;
+        definition = attribute.value;
+        binding = Twine.bindingTypes[type];
+        if (!binding) {
+          return;
         }
         fn = binding(node, context, definition, element);
         if (fn) {
-          element.bindings.push(fn);
+          return element.bindings.push(fn);
         }
-      }
+      });
       if (newContextKey = Twine.getAttribute(node, 'context')) {
         keypath = keypathForKey(node, newContextKey);
         if (keypath[0] === '$root') {
@@ -118,15 +123,15 @@
         }
       }
       callbacks = currentBindingCallbacks;
-      ref1 = node.children || [];
-      for (j = 0, len = ref1.length; j < len; j++) {
-        childNode = ref1[j];
+      ref = node.children || [];
+      for (j = 0, len = ref.length; j < len; j++) {
+        childNode = ref[j];
         bind(context, childNode, newContextKey != null ? null : indexes);
       }
       Twine.count = nodeCount;
-      ref2 = callbacks || [];
-      for (k = 0, len1 = ref2.length; k < len1; k++) {
-        callback = ref2[k];
+      ref1 = callbacks || [];
+      for (k = 0, len1 = ref1.length; k < len1; k++) {
+        callback = ref1[k];
         callback();
       }
       currentBindingCallbacks = null;

--- a/lib/assets/javascripts/twine.coffee
+++ b/lib/assets/javascripts/twine.coffee
@@ -72,7 +72,7 @@
     element = findOrCreateElementForNode(node)
     element.bindings ?= []
     element.indexes ?= indexes
-    Array.from(node.attributes).forEach (attribute) ->
+    Array.prototype.slice.call(node.attributes).forEach (attribute) ->
       type = attribute.name
       type = type.slice(5) if type.startsWith('data-')
       definition = attribute.value

--- a/lib/assets/javascripts/twine.coffee
+++ b/lib/assets/javascripts/twine.coffee
@@ -283,7 +283,11 @@
     value not in ['true', 'false', 'null', 'undefined'] && keypathRegex.test(value)
 
   isDataAttribute = (value) ->
-    value[0] == 'd' && value[1] == 'a' && value[2] == 't' && value[3] == 'a' && value[4] == '-'
+    value[0] == 'd' &&
+    value[1] == 'a' &&
+    value[2] == 't' &&
+    value[3] == 'a' &&
+    value[4] == '-'
 
   fireCustomChangeEvent = (node) ->
     event = document.createEvent('CustomEvent')

--- a/lib/assets/javascripts/twine.coffee
+++ b/lib/assets/javascripts/twine.coffee
@@ -69,11 +69,16 @@
       element = findOrCreateElementForNode(node)
       element.indexes = indexes
 
-    for type, binding of Twine.bindingTypes when definition = Twine.getAttribute(node, type)
-      element = findOrCreateElementForNode(node)
-      element.bindings ?= []
-      element.indexes ?= indexes
+    element = findOrCreateElementForNode(node)
+    element.bindings ?= []
+    element.indexes ?= indexes
+    Array.from(node.attributes).forEach (attribute) ->
+      type = attribute.name
+      type = type.slice(5) if type.startsWith('data-')
+      definition = attribute.value
 
+      binding = Twine.bindingTypes[type]
+      return unless binding
       fn = binding(node, context, definition, element)
       element.bindings.push(fn) if fn
 

--- a/lib/assets/javascripts/twine.coffee
+++ b/lib/assets/javascripts/twine.coffee
@@ -381,7 +381,7 @@
   setupPropertyBinding = (attributeName, bindingName) ->
     booleanProp = attributeName in ['checked', 'indeterminate', 'disabled', 'readOnly']
 
-    Twine.bindingTypes["bind-#{bindingName}"] = (node, context, definition) ->
+    Twine.bindingTypes["bind-#{bindingName.toLowerCase()}"] = (node, context, definition) ->
       fn = wrapFunctionString(definition, '$context,$root,$arrayPointers', node)
       lastValue = undefined
       return refresh: ->

--- a/lib/assets/javascripts/twine.coffee
+++ b/lib/assets/javascripts/twine.coffee
@@ -73,24 +73,24 @@
     bindingConstructors = null
     for attribute in node.attributes
       type = attribute.name
-      type = type.slice(5) if type.slice(0, 5) == 'data-'
-      definition = attribute.value
+      type = type.slice(5) if isDataAttribute(type)
 
       constructor = Twine.bindingTypes[type]
       continue unless constructor
 
       bindingConstructors ?= []
+      definition = attribute.value
       if type == 'bind'
-        bindingConstructors.unshift({constructor, definition})
+        bindingConstructors.unshift([constructor, definition])
       else
-        bindingConstructors.push({constructor, definition})
+        bindingConstructors.push([constructor, definition])
 
     if bindingConstructors
       element ?= findOrCreateElementForNode(node)
       element.bindings ?= []
       element.indexes ?= indexes
 
-      for {constructor, definition} in bindingConstructors
+      for [constructor, definition] in bindingConstructors
         binding = constructor(node, context, definition, element)
         element.bindings.push(binding) if binding
 
@@ -281,6 +281,9 @@
 
   isKeypath = (value) ->
     value not in ['true', 'false', 'null', 'undefined'] && keypathRegex.test(value)
+
+  isDataAttribute = (value) ->
+    value[0] == 'd' && value[1] == 'a' && value[2] == 't' && value[3] == 'a' && value[4] == '-'
 
   fireCustomChangeEvent = (node) ->
     event = document.createEvent('CustomEvent')

--- a/lib/assets/javascripts/twine.coffee
+++ b/lib/assets/javascripts/twine.coffee
@@ -74,7 +74,7 @@
     element.indexes ?= indexes
     Array.prototype.slice.call(node.attributes).forEach (attribute) ->
       type = attribute.name
-      type = type.slice(5) if type.startsWith('data-')
+      type = type.slice(5) if type.slice(0, 5) == 'data-'
       definition = attribute.value
 
       binding = Twine.bindingTypes[type]

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -164,28 +164,53 @@ suite "Twine", ->
       node = setupView(testView, key: "<script>")
       assert.equal node.innerHTML, "&lt;script&gt;"
 
+    test "should be the first binding to run on input event", ->
+      testView = "<input type=\"text\" bind-event-input=\"eventFunc()\" data-bind=\"val\">"
+      context = {
+        eventFunc: @spy(),
+      }
+      bindGetter = @spy()
+      Object.defineProperty(context, 'val', {
+        get: bindGetter
+      })
+      node = setupView(testView, context)
+      context.eventFunc.reset()
+      bindGetter.reset()
+
+      triggerEvent node, "input"
+      sinon.assert.callOrder bindGetter, context.eventFunc
+
+    test "should be the first binding to run on keyup event", ->
+      testView = "<input type=\"text\" bind-event-keyup=\"eventFunc()\" data-bind=\"val\">"
+      context = {
+        eventFunc: @spy(),
+      }
+      bindGetter = @spy()
+      Object.defineProperty(context, 'val', {
+        get: bindGetter
+      })
+      node = setupView(testView, context)
+      context.eventFunc.reset()
+      bindGetter.reset()
+
+      triggerEvent node, "keyup"
+      sinon.assert.callOrder bindGetter, context.eventFunc
+
     test "should be the first binding to run on change event", ->
       testView = "<input type=\"text\" bind-event-change=\"eventFunc()\" data-bind=\"val\">"
       context = {
-        val: 1,
-        eventFunc: () -> this.val = this.val * 2
+        eventFunc: @spy(),
       }
+      bindGetter = @spy()
+      Object.defineProperty(context, 'val', {
+        get: bindGetter
+      })
       node = setupView(testView, context)
-      node.value = 2
+      context.eventFunc.reset()
+      bindGetter.reset()
+
       triggerEvent node, "change"
-
-      assert.equal context.val, 4
-
-    # test "should be the first binding to run on input event", ->
-    #   testView = "<input type=\"text\" bind-event-input=\"eventFunc()\" data-bind=\"bindFunc()\">"
-    #   node = setupView(testView, context = {
-    #     eventFunc: @spy(),
-    #     bindFunc: @spy()
-    #   })
-    #   context.eventFunc.reset()
-    #   context.bindFunc.reset()
-    #   triggerEvent node, "input"
-    #   sinon.assert.callOrder context.bindFunc, context.eventFunc
+      sinon.assert.callOrder bindGetter, context.eventFunc
 
   suite "data-bind-show attribute", ->
     test "should apply the \"hide\" class when falsy", ->

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -166,10 +166,11 @@ suite "Twine", ->
 
     test "should be the first binding to run on change event", ->
       testView = "<input type=\"text\" bind-event-change=\"eventFunc()\" data-bind=\"val\">"
-      node = setupView(testView, context = {
+      context = {
         val: 1,
         eventFunc: () -> this.val = this.val * 2
-      })
+      }
+      node = setupView(testView, context)
       node.value = 2
       triggerEvent node, "change"
 

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -171,7 +171,8 @@ suite "Twine", ->
       }
       bindGetter = @spy()
       Object.defineProperty(context, 'val', {
-        get: bindGetter
+        get: bindGetter,
+        set: @spy()
       })
       node = setupView(testView, context)
       context.eventFunc.reset()
@@ -187,7 +188,8 @@ suite "Twine", ->
       }
       bindGetter = @spy()
       Object.defineProperty(context, 'val', {
-        get: bindGetter
+        get: bindGetter,
+        set: @spy()
       })
       node = setupView(testView, context)
       context.eventFunc.reset()
@@ -203,7 +205,8 @@ suite "Twine", ->
       }
       bindGetter = @spy()
       Object.defineProperty(context, 'val', {
-        get: bindGetter
+        get: bindGetter,
+        set: @spy()
       })
       node = setupView(testView, context)
       context.eventFunc.reset()

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -164,6 +164,28 @@ suite "Twine", ->
       node = setupView(testView, key: "<script>")
       assert.equal node.innerHTML, "&lt;script&gt;"
 
+    test "should be the first binding to run on change event", ->
+      testView = "<input type=\"text\" bind-event-change=\"eventFunc()\" data-bind=\"val\">"
+      node = setupView(testView, context = {
+        val: 1,
+        eventFunc: () -> this.val = this.val * 2
+      })
+      node.value = 2
+      triggerEvent node, "change"
+
+      assert.equal context.val, 4
+
+    # test "should be the first binding to run on input event", ->
+    #   testView = "<input type=\"text\" bind-event-input=\"eventFunc()\" data-bind=\"bindFunc()\">"
+    #   node = setupView(testView, context = {
+    #     eventFunc: @spy(),
+    #     bindFunc: @spy()
+    #   })
+    #   context.eventFunc.reset()
+    #   context.bindFunc.reset()
+    #   triggerEvent node, "input"
+    #   sinon.assert.callOrder context.bindFunc, context.eventFunc
+
   suite "data-bind-show attribute", ->
     test "should apply the \"hide\" class when falsy", ->
       testView = "<div data-bind-show=\"key\"></div>"


### PR DESCRIPTION
### Why?
After some investigation into the performance of `Twine.bind` in [this doc](https://docs.google.com/document/d/1tA2zFtiY-J0PcYHqQkw59Ma6mK4pgWnXfBCTRowZ-s8/), @bouk found that the iteration over every binding type in `Twine.bindingTypes` was unnecessary and it would be more performant to instead iterate over the attributes of the node.


### Performance Test
I did a performance test on Shopify core by writing some equivalent JS on the master branch:
```js
element = findOrCreateElementForNode(node);
if (element.bindings == null) {
  element.bindings = [];
}
if (element.indexes == null) {
  element.indexes = indexes;
}

Array.from(node.attributes).forEach((attribute) => {
  let type = attribute.name
  let definition = attribute.value
  if (type.startsWith('data-')) {
    type = type.slice(5);
  }

  binding = Twine.bindingTypes[type]
  if (!binding) {
    return;
  }
  fn = binding(node, context, definition, element);
  if (fn) {
    element.bindings.push(fn);
  }
});
```

js <-- coffee by js2.coffee output:
![image](https://cloud.githubusercontent.com/assets/2578036/16571197/d4b2ba60-4224-11e6-838d-1c22dfd98e9b.png)

On the Home page the duration of `Twine.bind` caused by the page load was recorded as follows:

| Trial     | Before    | After    |
|-----------|-----------|----------|
| 1         | 148.07ms  | 129.85ms |
| 2         | 155.89ms  | 112.52ms |
| 3         | 170.32ms  | 123.46ms |
| 4         | 155.71ms  | 150.73ms |
| 5         | 168.24ms  | 118.74ms |
|           |           |          |
| Averages: | **159.646ms** | **127.06ms** |


### Changes
 - The `bind` function now iterates over `node.attributes` rather than `Twine.bindingTypes` since `node.attributes` will most likely be the smaller set.
 - Moved the `element = findOrCreateElementForNode` assignment outside of the loop to prevent unnecessary calls and repeated assignments.

**For review:**
@bouk @lemonmade @Shopify/tnt
cc
@Shopify/admin-fed @edward @GoodForOneFare 