### PR TITLE
Fix define order and add tests to cover behaviour

### DIFF
--- a/dist/twine.js
+++ b/dist/twine.js
@@ -99,7 +99,7 @@
           bindingConstructors = [];
         }
         definition = attribute.value;
-        if (type === 'bind') {
+        if (type === 'bind' || type === 'define') {
           bindingConstructors.unshift([constructor, definition]);
         } else {
           bindingConstructors.push([constructor, definition]);

--- a/dist/twine.js
+++ b/dist/twine.js
@@ -1,6 +1,5 @@
 (function() {
-  var indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; },
-    slice = [].slice;
+  var slice = [].slice;
 
   (function(root, factory) {
     if (typeof root.define === 'function' && root.define.amd) {
@@ -11,7 +10,7 @@
       return root.Twine = factory();
     }
   })(this, function() {
-    var Twine, arrayPointersForNode, attribute, bind, currentBindingCallbacks, defineArray, elements, eventName, findOrCreateElementForNode, fireCustomChangeEvent, getContext, getIndexesForElement, getValue, isDataAttribute, isKeypath, j, k, keyWithArrayIndex, keypathForKey, keypathRegex, len, len1, nodeArrayIndexes, nodeCount, preventDefaultForEvent, ref, ref1, refreshElement, refreshQueued, registry, requiresRegistry, rootContext, rootNode, setValue, setupEventBinding, setupPropertyBinding, stringifyNodeAttributes, valuePropertyForNode, wrapFunctionString;
+    var Twine, arrayPointersForNode, attribute, bind, bindingOrder, currentBindingCallbacks, defineArray, elements, eventName, findOrCreateElementForNode, fireCustomChangeEvent, getContext, getIndexesForElement, getValue, isDataAttribute, isKeypath, j, k, keyWithArrayIndex, keypathForKey, keypathRegex, len, len1, nodeArrayIndexes, nodeCount, preventDefaultForEvent, ref, ref1, refreshElement, refreshQueued, registry, requiresRegistry, rootContext, rootNode, setValue, setupEventBinding, setupPropertyBinding, stringifyNodeAttributes, valuePropertyForNode, wrapFunctionString;
     Twine = {};
     Twine.shouldDiscardEvent = {};
     elements = {};
@@ -63,7 +62,7 @@
       }
     };
     bind = function(context, node, indexes, forceSaveContext) {
-      var ORDERED_BINDINGS, attribute, binding, bindingConstructors, callback, callbacks, childNode, constructor, defineArrayAttr, definition, element, j, k, key, keypath, l, len, len1, len2, len3, len4, m, n, newContextKey, newIndexes, ref, ref1, ref2, ref3, ref4, ref5, type, value;
+      var _, attribute, binding, bindingConstructors, callback, callbacks, childNode, constructor, defineArrayAttr, definition, element, j, k, key, keypath, l, len, len1, len2, len3, m, newContextKey, newIndexes, ref, ref1, ref2, ref3, ref4, type, value;
       currentBindingCallbacks = [];
       element = null;
       if (node.bindingId) {
@@ -84,7 +83,6 @@
         element = findOrCreateElementForNode(node);
         element.indexes = indexes;
       }
-      ORDERED_BINDINGS = ['define', 'bind'];
       bindingConstructors = null;
       ref = node.attributes;
       for (j = 0, len = ref.length; j < len; j++) {
@@ -98,16 +96,10 @@
           continue;
         }
         if (bindingConstructors == null) {
-          bindingConstructors = {
-            others: []
-          };
+          bindingConstructors = [];
         }
         definition = attribute.value;
-        if (indexOf.call(ORDERED_BINDINGS, type) >= 0) {
-          bindingConstructors[type] = [constructor, definition];
-        } else {
-          bindingConstructors.others.push([constructor, definition]);
-        }
+        bindingConstructors.push([type, constructor, definition]);
       }
       if (bindingConstructors) {
         if (element == null) {
@@ -119,20 +111,9 @@
         if (element.indexes == null) {
           element.indexes = indexes;
         }
-        for (k = 0, len1 = ORDERED_BINDINGS.length; k < len1; k++) {
-          type = ORDERED_BINDINGS[k];
-          if (!(bindingConstructors[type] != null)) {
-            continue;
-          }
-          ref1 = bindingConstructors[type], constructor = ref1[0], definition = ref1[1];
-          binding = constructor(node, context, definition, element);
-          if (binding) {
-            element.bindings.push(binding);
-          }
-        }
-        ref2 = bindingConstructors.others;
-        for (l = 0, len2 = ref2.length; l < len2; l++) {
-          ref3 = ref2[l], constructor = ref3[0], definition = ref3[1];
+        ref1 = bindingConstructors.sort(bindingOrder);
+        for (k = 0, len1 = ref1.length; k < len1; k++) {
+          ref2 = ref1[k], _ = ref2[0], constructor = ref2[1], definition = ref2[2];
           binding = constructor(node, context, definition, element);
           if (binding) {
             element.bindings.push(binding);
@@ -159,15 +140,15 @@
         }
       }
       callbacks = currentBindingCallbacks;
-      ref4 = node.children || [];
-      for (m = 0, len3 = ref4.length; m < len3; m++) {
-        childNode = ref4[m];
+      ref3 = node.children || [];
+      for (l = 0, len2 = ref3.length; l < len2; l++) {
+        childNode = ref3[l];
         bind(context, childNode, newContextKey != null ? null : indexes);
       }
       Twine.count = nodeCount;
-      ref5 = callbacks || [];
-      for (n = 0, len4 = ref5.length; n < len4; n++) {
-        callback = ref5[n];
+      ref4 = callbacks || [];
+      for (m = 0, len3 = ref4.length; m < len3; m++) {
+        callback = ref4[m];
         callback();
       }
       currentBindingCallbacks = null;
@@ -438,6 +419,23 @@
       event = document.createEvent('CustomEvent');
       event.initCustomEvent('bindings:change', true, false, {});
       return node.dispatchEvent(event);
+    };
+    bindingOrder = function(arg, arg1) {
+      var ORDERED_BINDINGS, firstType, secondType;
+      firstType = arg[0];
+      secondType = arg1[0];
+      ORDERED_BINDINGS = {
+        define: 1,
+        bind: 2,
+        "eval": 3
+      };
+      if (!ORDERED_BINDINGS[firstType]) {
+        return 1;
+      }
+      if (!ORDERED_BINDINGS[secondType]) {
+        return -1;
+      }
+      return ORDERED_BINDINGS[firstType] - ORDERED_BINDINGS[secondType];
     };
     Twine.bindingTypes = {
       bind: function(node, context, definition) {

--- a/lib/assets/javascripts/twine.coffee
+++ b/lib/assets/javascripts/twine.coffee
@@ -80,7 +80,7 @@
 
       bindingConstructors ?= []
       definition = attribute.value
-      if type == 'bind'
+      if type == 'bind' || type == 'define'
         bindingConstructors.unshift([constructor, definition])
       else
         bindingConstructors.push([constructor, definition])

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -149,6 +149,18 @@ suite "Twine", ->
       Twine.refreshImmediately()
       assert.isTrue options[2].selected
 
+    test "should work with define before bind in a two-way binding", ->
+      testView = "<input type=\"text\" data-define=\"{key: 'value'}\" data-bind=\"key\">"
+      node = setupView(testView, context = {})
+
+      assert.equal node.value, 'value'
+
+    test "should work with define after bind in a two-way binding", ->
+      testView = "<input type=\"text\" data-bind=\"key\" data-define=\"{key: 'value'}\">"
+      node = setupView(testView, context = {})
+
+      assert.equal node.value, 'value'
+
     test "should work with arbitrary javascript", ->
       testView = "<div data-bind=\"key * 2\"></div>"
       node = setupView(testView, key: 4)
@@ -165,7 +177,7 @@ suite "Twine", ->
       assert.equal node.innerHTML, "&lt;script&gt;"
 
     test "should be the first binding to run on input event", ->
-      testView = "<input type=\"text\" bind-event-input=\"eventFunc()\" data-bind=\"val\">"
+      testView = "<input type=\"text\" data-bind-event-input=\"eventFunc()\" data-bind=\"val\">"
       context = {
         eventFunc: @spy(),
       }
@@ -182,7 +194,7 @@ suite "Twine", ->
       sinon.assert.callOrder bindGetter, context.eventFunc
 
     test "should be the first binding to run on keyup event", ->
-      testView = "<input type=\"text\" bind-event-keyup=\"eventFunc()\" data-bind=\"val\">"
+      testView = "<input type=\"text\" data-bind-event-keyup=\"eventFunc()\" data-bind=\"val\">"
       context = {
         eventFunc: @spy(),
       }
@@ -199,7 +211,7 @@ suite "Twine", ->
       sinon.assert.callOrder bindGetter, context.eventFunc
 
     test "should be the first binding to run on change event", ->
-      testView = "<input type=\"text\" bind-event-change=\"eventFunc()\" data-bind=\"val\">"
+      testView = "<input type=\"text\" data-bind-event-change=\"eventFunc()\" data-bind=\"val\">"
       context = {
         eventFunc: @spy(),
       }
@@ -418,6 +430,15 @@ suite "Twine", ->
 
       assert.equal context.key, "value"
       assert.equal context.key2, "value2"
+
+    test "should run before eval", ->
+      testView = "<div eval=\"evalFunc(key)\" data-define=\"{key: 'value'}\"></div>"
+      context = {
+        evalFunc: @spy(),
+      }
+      setupView(testView, context)
+
+      assert.isTrue context.evalFunc.calledWith('value')
 
     test "should throw a helpful error if trying to define improperly", ->
       testView = "<div data-define=\"{key: 'value', key2: 'value2\"></div>"
@@ -1033,6 +1054,18 @@ suite "TwineLegacy", ->
       Twine.refreshImmediately()
       assert.isTrue options[2].selected
 
+    test "should work with define before bind in a two-way binding", ->
+      testView = "<input type=\"text\" define=\"{key: 'value'}\" bind=\"key\">"
+      node = setupView(testView, context = {})
+
+      assert.equal node.value, 'value'
+
+    test "should work with define after bind in a two-way binding", ->
+      testView = "<input type=\"text\" bind=\"key\" define=\"{key: 'value'}\">"
+      node = setupView(testView, context = {})
+
+      assert.equal node.value, 'value'
+
     test "should work with arbitrary javascript", ->
       testView = "<div bind=\"key * 2\"></div>"
       node = setupView(testView, key: 4)
@@ -1047,6 +1080,57 @@ suite "TwineLegacy", ->
       testView = "<div bind=\"key\"></div>"
       node = setupView(testView, key: "<script>")
       assert.equal node.innerHTML, "&lt;script&gt;"
+
+    test "should be the first binding to run on input event", ->
+      testView = "<input type=\"text\" bind-event-input=\"eventFunc()\" bind=\"val\">"
+      context = {
+        eventFunc: @spy(),
+      }
+      bindGetter = @spy()
+      Object.defineProperty(context, 'val', {
+        get: bindGetter,
+        set: @spy()
+      })
+      node = setupView(testView, context)
+      context.eventFunc.reset()
+      bindGetter.reset()
+
+      triggerEvent node, "input"
+      sinon.assert.callOrder bindGetter, context.eventFunc
+
+    test "should be the first binding to run on keyup event", ->
+      testView = "<input type=\"text\" bind-event-keyup=\"eventFunc()\" bind=\"val\">"
+      context = {
+        eventFunc: @spy(),
+      }
+      bindGetter = @spy()
+      Object.defineProperty(context, 'val', {
+        get: bindGetter,
+        set: @spy()
+      })
+      node = setupView(testView, context)
+      context.eventFunc.reset()
+      bindGetter.reset()
+
+      triggerEvent node, "keyup"
+      sinon.assert.callOrder bindGetter, context.eventFunc
+
+    test "should be the first binding to run on change event", ->
+      testView = "<input type=\"text\" bind-event-change=\"eventFunc()\" bind=\"val\">"
+      context = {
+        eventFunc: @spy(),
+      }
+      bindGetter = @spy()
+      Object.defineProperty(context, 'val', {
+        get: bindGetter,
+        set: @spy()
+      })
+      node = setupView(testView, context)
+      context.eventFunc.reset()
+      bindGetter.reset()
+
+      triggerEvent node, "change"
+      sinon.assert.callOrder bindGetter, context.eventFunc
 
   suite "bind-show attribute", ->
     test "should apply the \"hide\" class when falsy", ->
@@ -1241,6 +1325,15 @@ suite "TwineLegacy", ->
 
       assert.equal context.key, "value"
       assert.equal context.key2, "value2"
+
+    test "should run before eval", ->
+      testView = "<div eval=\"evalFunc(key)\" define=\"{key: 'value'}\"></div>"
+      context = {
+        evalFunc: @spy(),
+      }
+      setupView(testView, context)
+
+      assert.isTrue context.evalFunc.calledWith('value')
 
     test "should throw a helpful error if trying to define improperly", ->
       testView = "<div define=\"{key: 'value', key2: 'value2\"></div>"


### PR DESCRIPTION
#### What's the Problem?
After [Bind performance](https://github.com/Shopify/twine/pull/79) shipped last week to Shopify core, where the order of binding construction was now changed to rely on the order of attribute definition, a new edge case was found for `define` in relation to `eval` that caused a new error of which 99.6% of instances were from Firefox:

![image](https://cloud.githubusercontent.com/assets/2578036/16904504/b0fff538-4c65-11e6-8401-4a7074d522e3.png)

The scenario is when the `eval` binding is constructed before `define`. `eval` executes its definition immediately and if it depends on variables in the `define` definition then it throws an error.

#### Why does this happen?

If the attributes are arranged like so,
```html
<div data-eval="foo()" define="{foo: function() {}}"></div>
```
 then `data-eval` will execute first.

However even if the attributes are arranged the other way like this: 
```html
<div define="{foo: function() {}}" data-eval="foo()"></div>
```
then **Firefox will sort the attributes alphabetically** when generating the array for `node.attributes` and therefore `data-eval` still executes first. This does not happen on Chrome though, which is why this was not caught in testing.

#### What's the fix?

 - `define` joins the ranks of `bind` as a first order binding that needs to be constructed first before all other bindings.
 - It does not matter which of the two comes first in the list of `bindingConstructors` as long as they are both in the first two.

How are you sure that `define` does not need to come after `bind` and vice versa?

Let's lay out the dependencies and side effects of each binding **constructor**:
 - **`define`**
   - Dependencies:
     - Uses `context` to evaluate the new definition values.
   - Side Effects:
     - [Assigns the new definition values to `context`.](https://github.com/Shopify/twine/blob/fix-define-order/lib/assets/javascripts/twine.coffee#L377)
     - Does not attach listeners to any events.
 - **`bind`**
   - Dependencies:
     - Uses `context` to fetch the value of the `bind` key if it exists and is a 2-way-binding.
   - Side Effects:
     - [Assigns the key-value pair of the `bind` definition to the `context` if the key doesn't already exist in the `context` and is a 2-way-binding.](https://github.com/Shopify/twine/blob/fix-define-order/lib/assets/javascripts/twine.coffee#L334)
     - [Attaches an event listener to `'input keyup change'`.](https://github.com/Shopify/twine/blob/fix-define-order/lib/assets/javascripts/twine.coffee#L342)

**If `define` executes before `bind`**, then `bind` successfully fetches the value of its key from the `context`.

**If `bind` executes before `define`**, then `bind` sets the incorrect/empty key-value pair in the `context` at first, but when `define` executes, it overrides the same key with the correct value.

In either case, the context ends up with the correct definitions and `bind` still is the first binding to attach its listener to `'input keyup change'`. Therefore `define` and `bind` do not have order dependencies between each other.

I have added tests to preserve this non-dependency between `define` and `bind` in addition to a test ensuring `define` is run before `eval`.

**For Review:**
@GoodForOneFare @DrewMartin @Shopify/tnt 