### PR TITLE
Keypath Function

### DIFF
--- a/dist/twine.js
+++ b/dist/twine.js
@@ -367,21 +367,21 @@
       var e, error, keypath;
       if (isKeypath(code) && (keypath = keypathForKey(node, code))) {
         if (keypath[0] === '$root') {
-          return function($context, $root) {
+          return function($context, $root, arrayIndexes, event) {
             var value;
             value = getValue($root, keypath);
             if (typeof value === 'function') {
-              return value();
+              return value(node, event);
             } else {
               return value;
             }
           };
         } else {
-          return function($context, $root) {
+          return function($context, $root, arrayIndexes, event) {
             var value;
             value = getValue($context, keypath);
             if (typeof value === 'function') {
-              return value();
+              return value(node, event);
             } else {
               return value;
             }
@@ -622,7 +622,7 @@
       return Twine.bindingTypes["bind-event-" + eventName] = function(node, context, definition) {
         var onEventHandler;
         onEventHandler = function(event, data) {
-          var base, discardEvent;
+          var base, discardEvent, fn;
           discardEvent = typeof (base = Twine.shouldDiscardEvent)[eventName] === "function" ? base[eventName](event) : void 0;
           if (discardEvent || preventDefaultForEvent(event)) {
             event.preventDefault();
@@ -630,7 +630,8 @@
           if (discardEvent) {
             return;
           }
-          wrapFunctionString(definition, '$context,$root,$arrayPointers,event,data', node).call(node, context, rootContext, arrayPointersForNode(node, context), event, data);
+          fn = wrapFunctionString(definition, '$context,$root,$arrayPointers,event,data', node);
+          fn.call(node, context, rootContext, arrayPointersForNode(node, context), event, data);
           return Twine.refreshImmediately();
         };
         $(node).on(eventName, onEventHandler);

--- a/dist/twine.js
+++ b/dist/twine.js
@@ -368,11 +368,23 @@
       if (isKeypath(code) && (keypath = keypathForKey(node, code))) {
         if (keypath[0] === '$root') {
           return function($context, $root) {
-            return getValue($root, keypath);
+            var value;
+            value = getValue($root, keypath);
+            if (typeof value === 'function') {
+              return value();
+            } else {
+              return value;
+            }
           };
         } else {
           return function($context, $root) {
-            return getValue($context, keypath);
+            var value;
+            value = getValue($context, keypath);
+            if (typeof value === 'function') {
+              return value();
+            } else {
+              return value;
+            }
           };
         }
       } else {

--- a/lib/assets/javascripts/twine.coffee
+++ b/lib/assets/javascripts/twine.coffee
@@ -253,9 +253,21 @@
   wrapFunctionString = (code, args, node) ->
     if isKeypath(code) && keypath = keypathForKey(node, code)
       if keypath[0] == '$root'
-        ($context, $root) -> getValue($root, keypath)
+        ($context, $root) ->
+          value = getValue($root, keypath)
+          if typeof value == 'function'
+            value()
+          else
+            value
+
       else
-        ($context, $root) -> getValue($context, keypath)
+        ($context, $root) ->
+          value = getValue($context, keypath)
+          if typeof value == 'function'
+            value()
+          else
+            value
+
     else
       code = "return #{code}"
       code = "with($arrayPointers) { #{code} }" if nodeArrayIndexes(node)

--- a/lib/assets/javascripts/twine.coffee
+++ b/lib/assets/javascripts/twine.coffee
@@ -253,18 +253,17 @@
   wrapFunctionString = (code, args, node) ->
     if isKeypath(code) && keypath = keypathForKey(node, code)
       if keypath[0] == '$root'
-        ($context, $root) ->
+        ($context, $root, arrayIndexes, event) ->
           value = getValue($root, keypath)
           if typeof value == 'function'
-            value()
+            value(node, event)
           else
             value
-
       else
-        ($context, $root) ->
+        ($context, $root, arrayIndexes, event) ->
           value = getValue($context, keypath)
           if typeof value == 'function'
-            value()
+            value(node, event)
           else
             value
 
@@ -441,7 +440,9 @@
 
         return if discardEvent
 
-        wrapFunctionString(definition, '$context,$root,$arrayPointers,event,data', node).call(node, context, rootContext, arrayPointersForNode(node, context), event, data)
+        wrapFunctionString(definition, '$context,$root,$arrayPointers,event,data', node)
+          .call(node, context, rootContext, arrayPointersForNode(node, context), event, data)
+
         Twine.refreshImmediately()
       $(node).on eventName, onEventHandler
 

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -32,9 +32,27 @@ suite "Twine", ->
       node = setupView(testView, key: {nested: { more: "value"}})
       assert.equal node.innerHTML, "value"
 
+    test "should bind compound keypath functions", ->
+      testView = "<div data-bind=\"key.nested.more\"></div>"
+      node = setupView(testView, key: {nested: { more: () -> "value"}})
+      assert.equal node.innerHTML, "value"
+
     test "should bind array accessor keypaths", ->
       testView = "<input data-bind=\"key[0]\">"
       node = setupView(testView, context = key: ["value"])
+      assert.equal node.value, "value"
+
+      context.key[0] = "new"
+      Twine.refreshImmediately()
+      assert.equal node.value, "new"
+
+      node.value = "value"
+      triggerEvent node, "change"
+      assert.equal node.value, "value"
+
+    test "should bind array accessor keypath functions", ->
+      testView = "<input data-bind=\"key[0]\">"
+      node = setupView(testView, context = key: [() -> "value"])
       assert.equal node.value, "value"
 
       context.key[0] = "new"
@@ -363,6 +381,19 @@ suite "Twine", ->
       $(node).trigger 'submit'
 
       assert.isTrue context.fn.calledOnce
+
+    test "should execute keypath function passing in node, event", (done) ->
+      testView = "<form data-bind-event-submit=\"fn\"></form>"
+      event = $.Event('submit')
+
+      node = setupView(testView, context = {
+        fn: (passedNode, passedEvent) ->
+          assert.equal(node, passedNode)
+          assert.equal(passedEvent, event)
+          done()
+      })
+
+      $(node).trigger(event)
 
     test "unbind should remove event listener", ->
       testView = "<div data-bind-event-click=\"fn()\"></div>"

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -22,6 +22,11 @@ suite "Twine", ->
       node = setupView(testView, key: "value")
       assert.equal node.innerHTML, "value"
 
+    test "should bind basic keypath functions", ->
+      testView = "<div data-bind=\"key\"></div>"
+      node = setupView(testView, key: () -> "value")
+      assert.equal node.innerHTML, "value"
+
     test "should bind compound keypaths", ->
       testView = "<div data-bind=\"key.nested.more\"></div>"
       node = setupView(testView, key: {nested: { more: "value"}})
@@ -350,6 +355,14 @@ suite "Twine", ->
 
       assert.isTrue context.fn.calledOnce
       assert.isTrue context.fn.calledWith(data)
+
+    test "should work with keypath", ->
+      testView = "<form data-bind-event-submit=\"fn\"></form>"
+      node = setupView(testView, context = fn: @spy())
+
+      $(node).trigger 'submit'
+
+      assert.isTrue context.fn.calledOnce
 
     test "unbind should remove event listener", ->
       testView = "<div data-bind-event-click=\"fn()\"></div>"


### PR DESCRIPTION
## What
This PR adds support for keypath functions. 

## How
Since twine is already checking if any bind looks like a keypath, we simply check if the value we get from a keypath is a function, and execute it if it is. There's minimal overhead here because we are already performing the keypath check on every bind.

## Why
- Evaling code is slower than just executing a function
- Evaling code makes debuggers sad and code hard to step through or put breakpoints in (nobody enjoys seeing error - source: VM231234124)
- We are already running the keypath check for simple values
- We have a lot of bindings that just look like `data-bind-event-click="foo(event)"`
- We have places where the pattern of `data-bind="foo.calculatedThing"` is approximated with eval

## Examples (trivial):
**Current**
```
<a class="next-list__item" data-bind-event-click="bulkDeleteCollectionsModal.show()">Delete selected collections</a>
```
**Keypath version**
```
<a class="next-list__item" data-bind-event-click="bulkDeleteCollectionsModal.show">Delete selected collections</a>
```

**Current**
```
'data-bind-event-click' => 'nextNavigation.goTo(event)',
```
**Keypath version**
```
'data-bind-event-click' => 'nextNavigation.goTo',
```

## Comments pls
FED folks who use lots of twine:
@WillsonSmith 
@dan-menard 
Reviewer folks
@Shopify/tnt 
@pushrax 
@qq99 
