### PR TITLE
Remove jQuery.toggleClass

### DIFF
--- a/dist/twine.js
+++ b/dist/twine.js
@@ -523,7 +523,9 @@
               return;
             }
             if (lastValue = newValue) {
-              return node.classList.toggle('hide');
+              return node.classList.add('hide');
+            } else {
+              return node.classList.remove('hide');
             }
           }
         };

--- a/dist/twine.js
+++ b/dist/twine.js
@@ -522,7 +522,9 @@
             if (newValue === lastValue) {
               return;
             }
-            return $(node).toggleClass('hide', lastValue = newValue);
+            if (lastValue = newValue) {
+              return node.classList.toggle('hide');
+            }
           }
         };
       },

--- a/lib/assets/javascripts/twine.coffee
+++ b/lib/assets/javascripts/twine.coffee
@@ -366,7 +366,11 @@
       return refresh: ->
         newValue = !fn.call(node, context, rootContext, arrayPointersForNode(node, context))
         return if newValue == lastValue
-        node.classList.toggle('hide') if lastValue = newValue
+
+        if lastValue = newValue
+          node.classList.add('hide')
+        else
+          node.classList.remove('hide')
 
     'bind-class': (node, context, definition) ->
       fn = wrapFunctionString(definition, '$context,$root,$arrayPointers', node)

--- a/lib/assets/javascripts/twine.coffee
+++ b/lib/assets/javascripts/twine.coffee
@@ -366,7 +366,7 @@
       return refresh: ->
         newValue = !fn.call(node, context, rootContext, arrayPointersForNode(node, context))
         return if newValue == lastValue
-        $(node).toggleClass('hide', lastValue = newValue)
+        node.classList.toggle('hide') if lastValue = newValue
 
     'bind-class': (node, context, definition) ->
       fn = wrapFunctionString(definition, '$context,$root,$arrayPointers', node)

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -253,6 +253,19 @@ suite "Twine", ->
       node = setupView(testView, key: true)
       assert.equal node.className, ""
 
+    test 'should toggle class on change', ->
+      testView = '<div data-bind-show="key"></div>'
+      node = setupView(testView, context = key: true)
+      assert.equal node.className, ''
+
+      context.key = false
+      Twine.refreshImmediately()
+      assert.equal node.className, 'hide'
+
+      context.key = true
+      Twine.refreshImmediately()
+      assert.equal node.className, ''
+
   suite "data-bind-class attribute", ->
     test "should apply the given classes when truthy", ->
       testView = "<div data-bind-class=\"{cls: key, cls2: false}\"></div>"
@@ -1195,6 +1208,19 @@ suite "TwineLegacy", ->
       testView = "<div bind-show=\"true\"></div>"
       node = setupView(testView, key: true)
       assert.equal node.className, ""
+
+    test 'should toggle class on change', ->
+      testView = '<div bind-show="key"></div>'
+      node = setupView(testView, context = key: true)
+      assert.equal node.className, ''
+
+      context.key = false
+      Twine.refreshImmediately()
+      assert.equal node.className, 'hide'
+
+      context.key = true
+      Twine.refreshImmediately()
+      assert.equal node.className, ''
 
   suite "bind-class attribute", ->
     test "should apply the given classes when truthy", ->


### PR DESCRIPTION
Addresses #50. Should be noted that `classList.toggle` still doesn't work on SVGs in IE11. Everything else should be good according to [caniuse](http://caniuse.com/#search=classlist).

Very small change but thought I would go ahead and do it.

cc @Shopify/tnt 
