### PR TITLE
Don’t iterate over dynamically added nodes for bind/unbind

### DIFF
--- a/dist/twine.js
+++ b/dist/twine.js
@@ -12,7 +12,7 @@
       return root.Twine = factory(root.jQuery);
     }
   })(this, function(jQuery) {
-    var Twine, arrayPointersForNode, attribute, bind, bindingOrder, currentBindingCallbacks, defineArray, elements, eventName, findOrCreateElementForNode, fireCustomChangeEvent, getContext, getIndexesForElement, getValue, isDataAttribute, isKeypath, j, k, keyWithArrayIndex, keypathForKey, keypathRegex, len, len1, nodeArrayIndexes, nodeCount, preventDefaultForEvent, ref, ref1, refreshCallbacks, refreshElement, refreshQueued, registry, requiresRegistry, rootContext, rootNode, setValue, setupEventBinding, setupPropertyBinding, stringifyNodeAttributes, valuePropertyForNode, wrapFunctionString;
+    var Twine, arrayPointersForNode, attribute, bind, bindingOrder, childrenForNode, currentBindingCallbacks, defineArray, elements, eventName, findOrCreateElementForNode, fireCustomChangeEvent, getContext, getIndexesForElement, getValue, isDataAttribute, isKeypath, j, k, keyWithArrayIndex, keypathForKey, keypathRegex, len, len1, nodeArrayIndexes, nodeCount, preventDefaultForEvent, ref, ref1, refreshCallbacks, refreshElement, refreshQueued, registry, requiresRegistry, rootContext, rootNode, setValue, setupEventBinding, setupPropertyBinding, stringifyNodeAttributes, valuePropertyForNode, wrapFunctionString;
     Twine = {};
     Twine.shouldDiscardEvent = {};
     elements = {};
@@ -143,7 +143,7 @@
         }
       }
       callbacks = currentBindingCallbacks;
-      ref3 = node.children || [];
+      ref3 = childrenForNode(node);
       for (l = 0, len2 = ref3.length; l < len2; l++) {
         childNode = ref3[l];
         bind(context, childNode, newContextKey != null ? null : indexes);
@@ -156,6 +156,13 @@
       }
       currentBindingCallbacks = null;
       return Twine;
+    };
+    childrenForNode = function(node) {
+      if (node.children) {
+        return Array.prototype.slice.call(node.children, 0);
+      } else {
+        return [];
+      }
     };
     findOrCreateElementForNode = function(node) {
       var name1;
@@ -230,7 +237,7 @@
         delete elements[id];
         delete node.bindingId;
       }
-      ref1 = node.children || [];
+      ref1 = childrenForNode(node);
       for (k = 0, len1 = ref1.length; k < len1; k++) {
         childNode = ref1[k];
         Twine.unbind(childNode);

--- a/lib/assets/javascripts/twine.coffee
+++ b/lib/assets/javascripts/twine.coffee
@@ -110,12 +110,9 @@
 
     callbacks = currentBindingCallbacks
 
-    # IE and Safari don't support node.children for DocumentFragment and SVGElement nodes.
-    # If the element supports children we continue to traverse the children, otherwise
-    # we stop traversing that subtree.
-    # https://developer.mozilla.org/en-US/docs/Web/API/ParentNode.children
-    # As a result, Twine are unsupported within DocumentFragment and SVGElement nodes.
-    bind(context, childNode, if newContextKey? then null else indexes) for childNode in (node.children || [])
+    # IE and Safari don't support node.children for DocumentFragment or SVGElement,
+    # See explanation in childrenForNode()
+    bind(context, childNode, if newContextKey? then null else indexes) for childNode in childrenForNode(node)
     Twine.count = nodeCount
 
     for callback in callbacks || []
@@ -123,6 +120,18 @@
     currentBindingCallbacks = null
 
     Twine
+
+  # IE and Safari don't support node.children for DocumentFragment and SVGElement nodes.
+  # If the element supports children we continue to traverse the children, otherwise
+  # we stop traversing that subtree.
+  # https://developer.mozilla.org/en-US/docs/Web/API/ParentNode.children
+  # As a result, Twine are unsupported within DocumentFragment and SVGElement nodes.
+  #
+  # We also prevent nodes from being iterated over more than once by locking
+  # the children, which prevents nodes that are dynamically inserted as siblings
+  # from causing double/ missed binds and unbinds.
+  childrenForNode = (node) ->
+    if node.children then Array.prototype.slice.call(node.children, 0) else []
 
   findOrCreateElementForNode = (node) ->
     node.bindingId ?= ++nodeCount
@@ -169,10 +178,9 @@
       delete elements[id]
       delete node.bindingId
 
-
     # IE and Safari don't support node.children for DocumentFragment or SVGElement,
-    # See explaination in bind()
-    Twine.unbind(childNode) for childNode in (node.children || [])
+    # See explanation in childrenForNode()
+    Twine.unbind(childNode) for childNode in childrenForNode(node)
     this
 
   # Returns the binding context for a node by looking up the tree.

--- a/lib/assets/javascripts/twine.coffee
+++ b/lib/assets/javascripts/twine.coffee
@@ -127,11 +127,11 @@
   # https://developer.mozilla.org/en-US/docs/Web/API/ParentNode.children
   # As a result, Twine are unsupported within DocumentFragment and SVGElement nodes.
   #
-  # We also prevent nodes from being iterated over more than once by locking
-  # the children, which prevents nodes that are dynamically inserted as siblings
-  # from causing double/ missed binds and unbinds.
+  # We also prevent nodes from being iterated over more than once by cacheing the
+  # lookup for children nodes, which prevents nodes that are dynamically inserted
+  # or removed as siblings from causing double/ missed binds and unbinds.
   childrenForNode = (node) ->
-    if node.children then Array.prototype.slice.call(node.children, 0) else []
+    if node.children then Array::slice.call(node.children, 0) else []
 
   findOrCreateElementForNode = (node) ->
     node.bindingId ?= ++nodeCount

--- a/test/twine_test.coffee
+++ b/test/twine_test.coffee
@@ -944,6 +944,18 @@ suite "Twine", ->
 
     assert.equal Twine.contextKey(node.firstChild, context.inner.inner), 'inner.inner'
 
+  test "dynamically inserted nodes should not be traversed when they happen during bind", ->
+    context = {
+      insertSibling: (node) ->
+        el = document.createElement('div')
+        el.setAttribute('data-eval', 'spy()')
+        node.insertAdjacentElement('afterend', el)
+      spy: @spy()
+    }
+    testView = '<div><div data-eval="insertSibling(this)"></div><div></div></div>'
+    setupView(testView, context)
+    assert.isFalse context.spy.called
+
 suite "TwineLegacy", ->
   setupView = (html, context) ->
     rootNode.innerHTML = html


### PR DESCRIPTION
This PR prevents iterating over dynamically inserted nodes during `Twine.bind`/ `Twine.unbind` by creating a locked array of children before starting iteration. This is in order to address an issue in our main app (https://github.com/Shopify/web/issues/7333, for those who have access), but more generally I feel this is a bug of the current implementation, not a feature. As such, I'd propose this as a patch release.