### PR TITLE
Add metadata to gemspec

### DIFF
--- a/twine-rails.gemspec
+++ b/twine-rails.gemspec
@@ -14,6 +14,13 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["lib/**/*", "README.md", "LICENSE"]
   spec.require_paths = ["lib"]
 
+  spec.metadata = {
+    'bug_tracker_uri' => 'https://github.com/Shopify/twine/issues',
+    'changelog_uri' => 'https://github.com/Shopify/twine/releases',
+    'source_code_uri' => 'https://github.com/Shopify/twine',
+    'allowed_push_host' => 'https://rubygems.org'
+  }
+
   spec.add_dependency "coffee-rails"
   spec.add_dependency "railties"
 


### PR DESCRIPTION
This PR should allow a new release of Twine to be published to rubygems. Whilst it was possible to manually publish the v2 release to [NPM](https://www.npmjs.com/package/twine) (and @lemonmade was kinda enough to do so), the correct way to publish to [Rubygems](https://rubygems.org/gems/twine-rails) is with ShipIt.

At the moment, using ShipIt fails with the following error:

![Screen Shot 2021-02-25 at 7 59 05 am](https://user-images.githubusercontent.com/69268/109071570-9e745080-773f-11eb-8e98-0d0e0178939e.jpg)

After searching around, it appears this was also encountered and solved by [bootsnap](https://github.com/Shopify/bootsnap/commit/3fff890bbe2e62b7e91f4bd09ca9b040e481fc73) (another Shopify open source gem) by specifying the `allowed_push_host` property.